### PR TITLE
Add unit test cases for plugin.go file

### DIFF
--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -9,10 +10,12 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams/mocks"
 	storemocks "github.com/mattermost/mattermost-plugin-msteams-sync/server/store/mocks"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/store/storemodels"
+	"github.com/mattermost/mattermost-plugin-msteams-sync/server/testutils"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
 )
@@ -52,7 +55,7 @@ func newTestPlugin() *Plugin {
 	plugin.API.(*plugintest.API).On("KVGet", lastReceivedChangeKey).Return([]byte{}, nil)
 	plugin.API.(*plugintest.API).On("GetServerVersion").Return("7.8.0")
 	plugin.API.(*plugintest.API).On("GetBundlePath").Return("./dist", nil)
-	plugin.API.(*plugintest.API).On("GetConfig").Return(&config)
+	// plugin.API.(*plugintest.API).On("GetConfig").Return(&config)
 	plugin.API.(*plugintest.API).On("Conn", true).Return("connection-id", nil)
 	plugin.API.(*plugintest.API).On("GetUnsanitizedConfig").Return(&config)
 	plugin.API.(*plugintest.API).On("SavePluginConfig", mock.Anything).Return(nil)
@@ -162,4 +165,212 @@ func TestMessageHasBeenPostedNewMessageWithFailureSending(t *testing.T) {
 	plugin.API.(*plugintest.API).On("LogError", "Unable to handle message sent", "error", "Unable to send the message").Return(nil)
 
 	plugin.MessageHasBeenPosted(nil, &post)
+}
+
+func TestGetURL(t *testing.T) {
+	mockSiteURLWithSuffix := "mockSiteURL/"
+	mockSiteURLWithoutSuffix := "mockSiteURL"
+	for _, test := range []struct {
+		Name     string
+		SetupAPI func(*plugintest.API)
+	}{
+		{
+			Name: "GetURL: With suffix '/'",
+			SetupAPI: func(api *plugintest.API) {
+				api.On("GetConfig").Return(&model.Config{
+					ServiceSettings: model.ServiceSettings{
+						SiteURL: &mockSiteURLWithSuffix,
+					},
+				}).Times(1)
+			},
+		},
+		{
+			Name: "GetURL: Without suffix '/'",
+			SetupAPI: func(api *plugintest.API) {
+				api.On("GetConfig").Return(&model.Config{
+					ServiceSettings: model.ServiceSettings{
+						SiteURL: &mockSiteURLWithoutSuffix,
+					},
+				}).Times(1)
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			p := newTestPlugin()
+			test.SetupAPI(p.API.(*plugintest.API))
+			resp := p.GetURL()
+			assert.Equal("mockSiteURL/plugins/com.mattermost.msteams-sync", resp)
+		})
+	}
+}
+
+func TestGetClientForUser(t *testing.T) {
+	for _, test := range []struct {
+		Name          string
+		SetupStore    func(*storemocks.Store)
+		ExpectedError string
+	}{
+		{
+			Name: "GetClientForUser: Unable to get the token",
+			SetupStore: func(store *storemocks.Store) {
+				store.On("GetTokenForMattermostUser", testutils.GetID()).Return(nil, nil).Times(1)
+			},
+			ExpectedError: "not connected user",
+		},
+		{
+			Name: "GetClientForUser: Valid",
+			SetupStore: func(store *storemocks.Store) {
+				store.On("GetTokenForMattermostUser", testutils.GetID()).Return(&oauth2.Token{}, nil).Times(1)
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			p := newTestPlugin()
+			test.SetupStore(p.store.(*storemocks.Store))
+			resp, err := p.GetClientForUser(testutils.GetID())
+			if test.ExpectedError != "" {
+				assert.Nil(resp)
+				assert.EqualError(err, test.ExpectedError)
+			} else {
+				assert.Nil(err)
+				assert.NotNil(resp)
+			}
+		})
+	}
+}
+
+func TestGetClientForTeamsUser(t *testing.T) {
+	for _, test := range []struct {
+		Name          string
+		SetupStore    func(*storemocks.Store)
+		ExpectedError string
+	}{
+		{
+			Name: "GetClientForTeamsUser: Unable to get the token",
+			SetupStore: func(store *storemocks.Store) {
+				store.On("GetTokenForMSTeamsUser", testutils.GetTeamUserID()).Return(nil, nil).Times(1)
+			},
+			ExpectedError: "not connected user",
+		},
+		{
+			Name: "GetClientForTeamsUser: Valid",
+			SetupStore: func(store *storemocks.Store) {
+				store.On("GetTokenForMSTeamsUser", testutils.GetTeamUserID()).Return(&oauth2.Token{}, nil).Times(1)
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			p := newTestPlugin()
+			test.SetupStore(p.store.(*storemocks.Store))
+			resp, err := p.GetClientForTeamsUser(testutils.GetTeamUserID())
+			if test.ExpectedError != "" {
+				assert.Nil(resp)
+				assert.EqualError(err, test.ExpectedError)
+			} else {
+				assert.Nil(err)
+				assert.NotNil(resp)
+			}
+		})
+	}
+}
+
+func TestSyncUsers(t *testing.T) {
+	for _, test := range []struct {
+		Name        string
+		SetupAPI    func(*plugintest.API)
+		SetupStore  func(*storemocks.Store)
+		SetupClient func(*mocks.Client)
+	}{
+		{
+			Name: "SyncUsers: Unable to get the user list",
+			SetupAPI: func(api *plugintest.API) {
+				api.On("LogError", "Unable to sync users", "error", mock.Anything).Times(1)
+			},
+			SetupStore: func(store *storemocks.Store) {},
+			SetupClient: func(client *mocks.Client) {
+				client.On("ListUsers").Return(nil, errors.New("unable to get the user list")).Times(1)
+			},
+		},
+		{
+			Name: "SyncUsers: Unable to get the users",
+			SetupAPI: func(api *plugintest.API) {
+				api.On("LogError", "Unable to sync users", "error", mock.Anything).Times(1)
+				api.On("GetUsers", &model.UserGetOptions{
+					Active:  true,
+					Page:    0,
+					PerPage: math.MaxInt32,
+				}).Return(nil, testutils.GetInternalServerAppError("unable to get the users")).Times(1)
+			},
+			SetupStore: func(store *storemocks.Store) {},
+			SetupClient: func(client *mocks.Client) {
+				client.On("ListUsers").Return([]msteams.User{
+					{
+						ID:          testutils.GetTeamUserID(),
+						DisplayName: "mockDisplayName",
+					},
+				}, nil).Times(1)
+			},
+		},
+		{
+			Name: "SyncUsers: Unable to create the user",
+			SetupAPI: func(api *plugintest.API) {
+				api.On("LogError", "Unable to sync user", "error", mock.Anything).Times(1)
+				api.On("GetUsers", &model.UserGetOptions{
+					Active:  true,
+					Page:    0,
+					PerPage: math.MaxInt32,
+				}).Return([]*model.User{
+					testutils.GetUser(model.SystemAdminRoleId, "test@test.com"),
+				}, nil).Times(1)
+				api.On("CreateUser", mock.AnythingOfType("*model.User")).Return(nil, testutils.GetInternalServerAppError("unable to create the user")).Times(1)
+			},
+			SetupStore: func(store *storemocks.Store) {},
+			SetupClient: func(client *mocks.Client) {
+				client.On("ListUsers").Return([]msteams.User{
+					{
+						ID:          testutils.GetTeamUserID(),
+						DisplayName: "mockDisplayName",
+					},
+				}, nil).Times(1)
+			},
+		},
+		{
+			Name: "SyncUsers: Unable to store the user info",
+			SetupAPI: func(api *plugintest.API) {
+				api.On("LogError", "Unable to sync user", "error", mock.Anything).Times(1)
+				api.On("GetUsers", &model.UserGetOptions{
+					Active:  true,
+					Page:    0,
+					PerPage: math.MaxInt32,
+				}).Return([]*model.User{
+					testutils.GetUser(model.SystemAdminRoleId, "test@test.com"),
+				}, nil).Times(1)
+				api.On("CreateUser", mock.AnythingOfType("*model.User")).Return(&model.User{
+					Id: testutils.GetID(),
+				}, nil).Times(1)
+			},
+			SetupStore: func(store *storemocks.Store) {
+				store.On("SetUserInfo", testutils.GetID(), testutils.GetTeamUserID(), mock.AnythingOfType("*oauth2.Token")).Return(testutils.GetInternalServerAppError("unable to store the user info")).Times(1)
+			},
+			SetupClient: func(client *mocks.Client) {
+				client.On("ListUsers").Return([]msteams.User{
+					{
+						ID:          testutils.GetTeamUserID(),
+						DisplayName: "mockDisplayName",
+					},
+				}, nil).Times(1)
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			p := newTestPlugin()
+			test.SetupAPI(p.API.(*plugintest.API))
+			test.SetupStore(p.store.(*storemocks.Store))
+			test.SetupClient(p.msteamsAppClient.(*mocks.Client))
+			p.syncUsers()
+		})
+	}
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -55,7 +55,6 @@ func newTestPlugin() *Plugin {
 	plugin.API.(*plugintest.API).On("KVGet", lastReceivedChangeKey).Return([]byte{}, nil)
 	plugin.API.(*plugintest.API).On("GetServerVersion").Return("7.8.0")
 	plugin.API.(*plugintest.API).On("GetBundlePath").Return("./dist", nil)
-	// plugin.API.(*plugintest.API).On("GetConfig").Return(&config)
 	plugin.API.(*plugintest.API).On("Conn", true).Return("connection-id", nil)
 	plugin.API.(*plugintest.API).On("GetUnsanitizedConfig").Return(&config)
 	plugin.API.(*plugintest.API).On("SavePluginConfig", mock.Anything).Return(nil)


### PR DESCRIPTION
#### Summary
Added unit test cases for some functions of plugin.go file:

- `GetURL`
- `GetClientForUser`
- `GetClientForTeamsUser`
- `SyncUsers`

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/43