### PR TITLE
Add unit test cases for plugin.go file

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -167,9 +167,11 @@ func (p *Plugin) startSubscriptions(ctx context.Context) {
 	maxRetries := 20
 	for {
 		resp, _ := http.Post(p.GetURL()+"/changes?validationToken=test-alive", "text/html", bytes.NewReader([]byte{}))
-		resp.Body.Close()
-		if resp.StatusCode == 200 {
-			break
+		if resp != nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				break
+			}
 		}
 
 		counter++

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -391,10 +391,8 @@ func TestConnectTeamsAppClient(t *testing.T) {
 			ExpectedError: "unable to connect to the app client",
 		},
 		{
-			Name: "ConnectTeamsAppClient: Valid",
-			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to connect to the app client", "error", mock.Anything).Times(1)
-			},
+			Name:     "ConnectTeamsAppClient: Valid",
+			SetupAPI: func(api *plugintest.API) {},
 			SetupClient: func(client *mocks.Client) {
 				client.On("Connect").Return(nil).Times(1)
 			},


### PR DESCRIPTION
#### Summary
Added unit test cases for some functions of plugin.go file:

- `ConnectTeamsAppClient`
- `Start`
- `GeneratePluginSecrets`


#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/43

