### PR TITLE
Add unit test cases for client.go file

### DIFF
--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -721,6 +721,10 @@ func GetResourceIds(resource string) ActivityIds {
 	result := ActivityIds{}
 	data := strings.Split(resource, "/")
 
+	if len(data) <= 1 {
+		return result
+	}
+
 	if strings.HasPrefix(data[0], "chats(") {
 		if len(data[0]) >= 9 {
 			result.ChatID = data[0][7 : len(data[0])-2]

--- a/server/msteams/client_test.go
+++ b/server/msteams/client_test.go
@@ -1,0 +1,115 @@
+package msteams
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-msteams-sync/server/testutils"
+	"github.com/stretchr/testify/assert"
+	msgraph "github.com/yaegashi/msgraph.go/beta"
+)
+
+func TestConvertToMessage(t *testing.T) {
+	teamsUserID := testutils.GetTeamUserID()
+	teamsUserDisplayName := "mockTeamsUserDisplayName"
+	teamsReplyID := "mockTeamsReplyID"
+	content := "mockContent"
+	subject := "mockSubject"
+	reactionType := "mockReactionType"
+	attachmentContent := "mockAttachmentContent"
+	attachmentContentType := "mockAttachmentContentType"
+	attachmentName := "mockAttachmentName"
+	attachmentURL := "mockAttachmentURL"
+	assert := assert.New(t)
+	resp := convertToMessage(&msgraph.ChatMessage{
+		From: &msgraph.IdentitySet{
+			User: &msgraph.Identity{
+				ID:          &teamsUserID,
+				DisplayName: &teamsUserDisplayName,
+			},
+		},
+		ReplyToID: &teamsReplyID,
+		Body: &msgraph.ItemBody{
+			Content: &content,
+		},
+		Subject:              &subject,
+		LastModifiedDateTime: &time.Time{},
+		Attachments: []msgraph.ChatMessageAttachment{
+			{
+				ContentType: &attachmentContentType,
+				Content:     &attachmentContent,
+				Name:        &attachmentName,
+				ContentURL:  &attachmentURL,
+			},
+		},
+		Reactions: []msgraph.ChatMessageReaction{
+			{
+				ReactionType: &reactionType,
+				User: &msgraph.IdentitySet{
+					User: &msgraph.Identity{
+						ID: &teamsUserID,
+					},
+				},
+			},
+		},
+	}, "mockTeamsTeamID", testutils.GetChannelID(), "mockChatID")
+
+	assert.Equal(Message{
+		UserID:          teamsUserID,
+		UserDisplayName: teamsUserDisplayName,
+		ReplyToID:       teamsReplyID,
+		Text:            content,
+		Subject:         subject,
+		LastUpdateAt:    time.Time{},
+		Attachments: []Attachment{
+			{
+				ContentType: attachmentContentType,
+				Content:     attachmentContent,
+				Name:        attachmentName,
+				ContentURL:  attachmentURL,
+			},
+		},
+		Reactions: []Reaction{
+			{
+				Reaction: reactionType,
+				UserID:   teamsUserID,
+			},
+		},
+		ChannelID: testutils.GetChannelID(),
+		TeamID:    "mockTeamsTeamID",
+		ChatID:    "mockChatID",
+	}, *resp)
+}
+
+func TestGetResourceIds(t *testing.T) {
+	for _, test := range []struct {
+		Name           string
+		Resource       string
+		ExpectedResult ActivityIds
+	}{
+		{
+			Name:     "GetResourceIds: With prefix chats(",
+			Resource: "chats(chat123-ID/mockChannel456-ID",
+			ExpectedResult: ActivityIds{
+				ChatID:    "hat123-",
+				MessageID: "l456-",
+			},
+		},
+		{
+			Name:     "GetResourceIds: Without prefix chats(",
+			Resource: "mockTeam123-ID/mockChannel456-ID/mockMessage789-ID/mockReply910-ID",
+			ExpectedResult: ActivityIds{
+				TeamID:    "m123-",
+				ChannelID: "l456-",
+				MessageID: "e789-",
+				ReplyID:   "910-",
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			resp := GetResourceIds(test.Resource)
+			assert.Equal(test.ExpectedResult, resp)
+		})
+	}
+}

--- a/server/msteams/client_test.go
+++ b/server/msteams/client_test.go
@@ -134,22 +134,23 @@ func TestGetResourceIds(t *testing.T) {
 			},
 		},
 		{
-			Name:     "GetResourceIds: Resource with multiple '/'",
-			Resource: "/////19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2///",
+			Name:           "GetResourceIds: Resource with multiple '/'",
+			Resource:       "/////19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2///",
+			ExpectedResult: ActivityIds{},
 		},
 		{
-			Name: "GetResourceIds: Empty resource",
+			Name:           "GetResourceIds: Empty resource",
+			ExpectedResult: ActivityIds{},
 		},
 		{
-			Name:     "GetResourceIds: Resource with small length",
-			Resource: "ID",
+			Name:           "GetResourceIds: Resource with small length",
+			Resource:       "ID",
+			ExpectedResult: ActivityIds{},
 		},
 		{
-			Name:     "GetResourceIds: Resource with large length",
-			Resource: "very-long-teams-ID-with-very-long-chat-ID",
-			ExpectedResult: ActivityIds{
-				TeamID: "ng-teams-ID-with-very-long-chat-",
-			},
+			Name:           "GetResourceIds: Resource with large length",
+			Resource:       "very-long-teams-ID-with-very-long-chat-ID",
+			ExpectedResult: ActivityIds{},
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
#### Summary
Added unit test cases for some functions of client.go file:

- `convertToMessage`
- `GetResourceIds`

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/55

