### PR TITLE
[MI-2969] Fixed the issue of wrong error message when trying to link/unlink DM or GM

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -127,6 +127,15 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, parameters []string) (*model.CommandResponse, *model.AppError) {
+	channel, appErr := p.API.GetChannel(args.ChannelId)
+	if appErr != nil {
+		return p.cmdError(args.UserId, args.ChannelId, "Unable to get the current channel information.")
+	}
+
+	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+		return p.cmdError(args.UserId, args.ChannelId, "Linking/unlinking a direct or group message is not allowed")
+	}
+
 	canLinkChannel := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PermissionManageChannelRoles)
 	if !canLinkChannel {
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to link the channel. You have to be a channel admin to link it.")
@@ -138,11 +147,6 @@ func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, 
 
 	if !p.store.CheckEnabledTeamByTeamID(args.TeamId) {
 		return p.cmdError(args.UserId, args.ChannelId, "This team is not enabled for MS Teams sync.")
-	}
-
-	channel, appErr := p.API.GetChannel(args.ChannelId)
-	if appErr != nil {
-		return p.cmdError(args.UserId, args.ChannelId, "Unable to get the current channel information.")
 	}
 
 	link, err := p.store.GetLinkByChannelID(args.ChannelId)
@@ -181,14 +185,18 @@ func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, 
 }
 
 func (p *Plugin) executeUnlinkCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	canLinkChannel := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PermissionManageChannelRoles)
-	if !canLinkChannel {
-		return p.cmdError(args.UserId, args.ChannelId, "Unable to unlink the channel, you have to be a channel admin to unlink it.")
-	}
-
 	channel, appErr := p.API.GetChannel(args.ChannelId)
 	if appErr != nil {
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to get the current channel information.")
+	}
+
+	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+		return p.cmdError(args.UserId, args.ChannelId, "Linking/unlinking a direct or group message is not allowed")
+	}
+
+	canLinkChannel := p.API.HasPermissionToChannel(args.UserId, args.ChannelId, model.PermissionManageChannelRoles)
+	if !canLinkChannel {
+		return p.cmdError(args.UserId, args.ChannelId, "Unable to unlink the channel, you have to be a channel admin to unlink it.")
 	}
 
 	if err := p.store.DeleteLinkByChannelID(channel.Id); err != nil {

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -528,7 +528,7 @@ func TestExecuteLinkCommand(t *testing.T) {
 			setupClient: func(c *mockClient.Client, uc *mockClient.Client) {},
 		},
 		{
-			description: "Unable to unlink channel as channel is either a direct or group message",
+			description: "Unable to link channel as channel is either a direct or group message",
 			parameters:  []string{testutils.GetTeamUserID(), ""},
 			args: &model.CommandArgs{
 				TeamId:    testutils.GetTeamUserID(),

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -35,11 +35,11 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
 					Id:   testutils.GetChannelID(),
 					Type: model.ChannelTypeOpen,
 				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					UserId:    "bot-user-id",
 					ChannelId: testutils.GetChannelID(),
@@ -57,11 +57,11 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 				ChannelId: "Mock-ChannelID",
 			},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", testutils.GetUserID(), "Mock-ChannelID", model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", "Mock-ChannelID").Return(&model.Channel{
 					Id:   "Mock-ChannelID",
 					Type: model.ChannelTypeOpen,
 				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), "Mock-ChannelID", model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					UserId:    "bot-user-id",
 					ChannelId: "Mock-ChannelID",
@@ -76,7 +76,6 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 			description: "Unable to get the current channel",
 			args:        &model.CommandArgs{},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", "", "", model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", "").Return(nil, testutils.GetInternalServerAppError("Error while getting the current channel.")).Once()
 				api.On("SendEphemeralPost", "", &model.Post{
 					UserId:  "bot-user-id",
@@ -92,11 +91,34 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Id:   testutils.GetChannelID(),
+					Type: model.ChannelTypeOpen,
+				}, nil).Times(1)
 				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(false).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					ChannelId: testutils.GetChannelID(),
 					UserId:    "bot-user-id",
 					Message:   "Unable to unlink the channel, you have to be a channel admin to unlink it.",
+				}).Return(testutils.GetPost(testutils.GetChannelID(), "bot-user-id")).Times(1)
+			},
+			setupStore: func(s *mockStore.Store) {},
+		},
+		{
+			description: "Unable to unlink channel as channel is either a direct or group message",
+			args: &model.CommandArgs{
+				UserId:    testutils.GetUserID(),
+				ChannelId: testutils.GetChannelID(),
+			},
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Id:   testutils.GetChannelID(),
+					Type: model.ChannelTypeDirect,
+				}, nil).Times(1)
+				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
+					ChannelId: testutils.GetChannelID(),
+					UserId:    "bot-user-id",
+					Message:   "Linking/unlinking a direct or group message is not allowed",
 				}).Return(testutils.GetPost(testutils.GetChannelID(), "bot-user-id")).Times(1)
 			},
 			setupStore: func(s *mockStore.Store) {},
@@ -373,10 +395,10 @@ func TestExecuteLinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
 					Type: model.ChannelTypeOpen,
 				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					UserId:    "bot-user-id",
 					ChannelId: testutils.GetChannelID(),
@@ -403,10 +425,10 @@ func TestExecuteLinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
 					Type: model.ChannelTypeOpen,
 				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					UserId:    "bot-user-id",
 					ChannelId: testutils.GetChannelID(),
@@ -432,6 +454,9 @@ func TestExecuteLinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Type: model.ChannelTypeOpen,
+				}, nil).Times(1)
 				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					UserId:    "bot-user-id",
@@ -447,6 +472,9 @@ func TestExecuteLinkCommand(t *testing.T) {
 			parameters:  []string{"", ""},
 			args:        &model.CommandArgs{},
 			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", "").Return(&model.Channel{
+					Type: model.ChannelTypeOpen,
+				}, nil).Times(1)
 				api.On("HasPermissionToChannel", "", "", model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", "", &model.Post{
 					UserId:  "bot-user-id",
@@ -465,7 +493,6 @@ func TestExecuteLinkCommand(t *testing.T) {
 				TeamId: testutils.GetTeamUserID(),
 			},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", "", "", model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", "").Return(nil, testutils.GetInternalServerAppError("Error while getting the current channel.")).Times(1)
 				api.On("SendEphemeralPost", "", &model.Post{
 					UserId:  "bot-user-id",
@@ -485,11 +512,36 @@ func TestExecuteLinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Type: model.ChannelTypeOpen,
+				}, nil).Times(1)
 				api.On("HasPermissionToChannel", "", testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(false).Times(1)
 				api.On("SendEphemeralPost", "", &model.Post{
 					UserId:    "bot-user-id",
 					ChannelId: testutils.GetChannelID(),
 					Message:   "Unable to link the channel. You have to be a channel admin to link it.",
+				}).Return(testutils.GetPost(testutils.GetChannelID(), "")).Times(1)
+			},
+			setupStore: func(s *mockStore.Store) {
+				s.On("CheckEnabledTeamByTeamID", testutils.GetTeamUserID()).Return(true).Times(1)
+			},
+			setupClient: func(c *mockClient.Client, uc *mockClient.Client) {},
+		},
+		{
+			description: "Unable to unlink channel as channel is either a direct or group message",
+			parameters:  []string{testutils.GetTeamUserID(), ""},
+			args: &model.CommandArgs{
+				TeamId:    testutils.GetTeamUserID(),
+				ChannelId: testutils.GetChannelID(),
+			},
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Type: model.ChannelTypeGroup,
+				}, nil).Times(1)
+				api.On("SendEphemeralPost", "", &model.Post{
+					UserId:    "bot-user-id",
+					ChannelId: testutils.GetChannelID(),
+					Message:   "Linking/unlinking a direct or group message is not allowed",
 				}).Return(testutils.GetPost(testutils.GetChannelID(), "")).Times(1)
 			},
 			setupStore: func(s *mockStore.Store) {
@@ -506,10 +558,10 @@ func TestExecuteLinkCommand(t *testing.T) {
 				ChannelId: testutils.GetChannelID(),
 			},
 			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
 					Type: model.ChannelTypeOpen,
 				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
 					UserId:    "bot-user-id",
 					ChannelId: testutils.GetChannelID(),


### PR DESCRIPTION
#### Summary
- Fixed the issue of wrong error message when trying to link/unlink DM or GM
- Fixed and added new unit tests

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/63
