### PR TITLE
[MI-2961] Fixed the issue of reactions not being in sync

### DIFF
--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -53,6 +53,7 @@ func New(plugin pluginIface) *ActivityHandler {
 	emojisReverseMap["laugh"] = "laughing"
 	emojisReverseMap["heart"] = "heart"
 	emojisReverseMap["surprised"] = "open_mouth"
+	emojisReverseMap["checkmarkbutton"] = "white_check_mark"
 
 	return &ActivityHandler{
 		plugin: plugin,
@@ -135,11 +136,13 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 	if err != nil || senderID == "" {
 		senderID = ah.plugin.GetBotUserID()
 	}
+
 	if chat != nil {
 		if !ah.plugin.GetSyncDirectMessages() {
 			// Skipping because direct/group messages are disabled
 			return
 		}
+
 		channelID, err = ah.getChatChannelID(chat, msg.UserID)
 		if err != nil {
 			ah.plugin.GetAPI().LogError("Unable to get original channel id", "error", err.Error())
@@ -301,7 +304,7 @@ func (ah *ActivityHandler) handleReactions(postID string, channelID string, reac
 	for _, reaction := range reactions {
 		emojiName, ok := emojisReverseMap[reaction.Reaction]
 		if !ok {
-			ah.plugin.GetAPI().LogError("Not code reaction found for reaction", "reaction", reaction.Reaction)
+			ah.plugin.GetAPI().LogError("No code reaction found for reaction", "reaction", reaction.Reaction)
 			continue
 		}
 		reactionUserID, err := ah.plugin.GetStore().TeamsToMattermostUserID(reaction.UserID)
@@ -330,7 +333,7 @@ func (ah *ActivityHandler) handleReactions(postID string, channelID string, reac
 		}
 		emojiName, ok := emojisReverseMap[reaction.Reaction]
 		if !ok {
-			ah.plugin.GetAPI().LogError("Not code reaction found for reaction", "reaction", reaction.Reaction)
+			ah.plugin.GetAPI().LogError("No code reaction found for reaction", "reaction", reaction.Reaction)
 			continue
 		}
 		if !postReactionsByUserAndEmoji[reactionUserID+emojiName] {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -108,10 +108,7 @@ func (p *Plugin) ReactionHasBeenAdded(c *plugin.Context, reaction *model.Reactio
 		return
 	}
 
-	user, _ := p.API.GetUser(post.UserId)
-
-	err = p.SetReaction(link.MSTeamsTeam, link.MSTeamsChannel, user, post, reaction.EmojiName)
-	if err != nil {
+	if err = p.SetReaction(link.MSTeamsTeam, link.MSTeamsChannel, reaction.UserId, post, reaction.EmojiName); err != nil {
 		p.API.LogError("Unable to handle message reaction set", "error", err.Error())
 	}
 }
@@ -148,9 +145,7 @@ func (p *Plugin) ReactionHasBeenRemoved(c *plugin.Context, reaction *model.React
 		return
 	}
 
-	user, _ := p.API.GetUser(post.UserId)
-
-	err = p.UnsetReaction(link.MSTeamsTeam, link.MSTeamsChannel, user, post, reaction.EmojiName)
+	err = p.UnsetReaction(link.MSTeamsTeam, link.MSTeamsChannel, reaction.UserId, post, reaction.EmojiName)
 	if err != nil {
 		p.API.LogError("Unable to handle message reaction unset", "error", err.Error())
 	}
@@ -233,8 +228,7 @@ func (p *Plugin) SetChatReaction(teamsMessageID, srcUser, channelID string, emoj
 		return err
 	}
 
-	err = client.SetChatReaction(chatID, teamsMessageID, srcUserID, emoji.Parse(":"+emojiName+":"))
-	if err != nil {
+	if err = client.SetChatReaction(chatID, teamsMessageID, srcUserID, emoji.Parse(":"+emojiName+":")); err != nil {
 		p.API.LogWarn("Error creating post reaction", "error", err.Error())
 		return err
 	}
@@ -242,7 +236,7 @@ func (p *Plugin) SetChatReaction(teamsMessageID, srcUser, channelID string, emoj
 	return nil
 }
 
-func (p *Plugin) SetReaction(teamID, channelID string, user *model.User, post *model.Post, emojiName string) error {
+func (p *Plugin) SetReaction(teamID, channelID, userID string, post *model.Post, emojiName string) error {
 	p.API.LogDebug("Setting reaction", "teamID", teamID, "channelID", channelID, "post", post, "emojiName", emojiName)
 
 	postInfo, err := p.store.GetPostInfoByMattermostID(post.Id)
@@ -262,7 +256,7 @@ func (p *Plugin) SetReaction(teamID, channelID string, user *model.User, post *m
 		}
 	}
 
-	client, err := p.GetClientForUser(user.Id)
+	client, err := p.GetClientForUser(userID)
 	if err != nil {
 		client, err = p.GetClientForUser(p.userID)
 		if err != nil {
@@ -270,7 +264,8 @@ func (p *Plugin) SetReaction(teamID, channelID string, user *model.User, post *m
 		}
 	}
 
-	err = client.SetReaction(teamID, channelID, parentID, postInfo.MSTeamsID, user.Id, emoji.Parse(":"+emojiName+":"))
+	teamsUserID, _ := p.store.MattermostToTeamsUserID(userID)
+	err = client.SetReaction(teamID, channelID, parentID, postInfo.MSTeamsID, teamsUserID, emoji.Parse(":"+emojiName+":"))
 	if err != nil {
 		p.API.LogWarn("Error creating post", "error", err.Error())
 		return err
@@ -298,8 +293,7 @@ func (p *Plugin) UnsetChatReaction(teamsMessageID, srcUser, channelID string, em
 		return err
 	}
 
-	err = client.UnsetChatReaction(chatID, teamsMessageID, srcUserID, emoji.Parse(":"+emojiName+":"))
-	if err != nil {
+	if err = client.UnsetChatReaction(chatID, teamsMessageID, srcUserID, emoji.Parse(":"+emojiName+":")); err != nil {
 		p.API.LogWarn("Error creating post", "error", err.Error())
 		return err
 	}
@@ -307,7 +301,7 @@ func (p *Plugin) UnsetChatReaction(teamsMessageID, srcUser, channelID string, em
 	return nil
 }
 
-func (p *Plugin) UnsetReaction(teamID, channelID string, user *model.User, post *model.Post, emojiName string) error {
+func (p *Plugin) UnsetReaction(teamID, channelID, userID string, post *model.Post, emojiName string) error {
 	p.API.LogDebug("Unsetting reaction", "teamID", teamID, "channelID", channelID, "post", post, "emojiName", emojiName)
 
 	postInfo, err := p.store.GetPostInfoByMattermostID(post.Id)
@@ -327,7 +321,7 @@ func (p *Plugin) UnsetReaction(teamID, channelID string, user *model.User, post 
 		}
 	}
 
-	client, err := p.GetClientForUser(user.Id)
+	client, err := p.GetClientForUser(userID)
 	if err != nil {
 		client, err = p.GetClientForUser(p.userID)
 		if err != nil {
@@ -335,8 +329,8 @@ func (p *Plugin) UnsetReaction(teamID, channelID string, user *model.User, post 
 		}
 	}
 
-	err = client.UnsetReaction(teamID, channelID, parentID, postInfo.MSTeamsID, user.Id, emoji.Parse(":"+emojiName+":"))
-	if err != nil {
+	teamsUserID, _ := p.store.MattermostToTeamsUserID(userID)
+	if err = client.UnsetReaction(teamID, channelID, parentID, postInfo.MSTeamsID, teamsUserID, emoji.Parse(":"+emojiName+":")); err != nil {
 		p.API.LogWarn("Error creating post", "error", err.Error())
 		return err
 	}

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -815,7 +815,12 @@ func (tc *ClientImpl) SetChatReaction(chatID, messageID, userID, emoji string) e
 	ctb := tc.client.Chats().ID(chatID).Messages().ID(messageID)
 	ctb.SetURL(ctb.URL() + "/setReaction")
 	ct := ctb.Request()
-	req, err := ct.NewJSONRequest("POST", "", map[string]string{"reactionType": emoji})
+	req, err := ct.NewJSONRequest("POST", "", map[string]interface{}{
+		"reactionType": emoji,
+		"user": map[string]string{
+			"id": userID,
+		},
+	})
 	if err != nil {
 		return err
 	}
@@ -840,7 +845,12 @@ func (tc *ClientImpl) SetReaction(teamID, channelID, parentID, messageID, userID
 		ctb := tc.client.Teams().ID(teamID).Channels().ID(channelID).Messages().ID(messageID)
 		ctb.SetURL(ctb.URL() + "/setReaction")
 		ct := ctb.Request()
-		req, err := ct.NewJSONRequest("POST", "", map[string]string{"reactionType": emoji})
+		req, err := ct.NewJSONRequest("POST", "", map[string]interface{}{
+			"reactionType": emoji,
+			"user": map[string]string{
+				"id": userID,
+			},
+		})
 		if err != nil {
 			return err
 		}
@@ -861,7 +871,12 @@ func (tc *ClientImpl) SetReaction(teamID, channelID, parentID, messageID, userID
 		ctb := tc.client.Teams().ID(teamID).Channels().ID(channelID).Messages().ID(parentID).Replies().ID(messageID)
 		ctb.SetURL(ctb.URL() + "/setReaction")
 		ct := ctb.Request()
-		req, err := ct.NewJSONRequest("POST", "", map[string]string{"reactionType": emoji})
+		req, err := ct.NewJSONRequest("POST", "", map[string]interface{}{
+			"reactionType": emoji,
+			"user": map[string]string{
+				"id": userID,
+			},
+		})
 		if err != nil {
 			return err
 		}
@@ -885,7 +900,12 @@ func (tc *ClientImpl) UnsetChatReaction(chatID, messageID, userID, emoji string)
 	ctb := tc.client.Chats().ID(chatID).Messages().ID(messageID)
 	ctb.SetURL(ctb.URL() + "/unsetReaction")
 	ct := ctb.Request()
-	req, err := ct.NewJSONRequest("POST", "", map[string]string{"reactionType": emoji})
+	req, err := ct.NewJSONRequest("POST", "", map[string]interface{}{
+		"reactionType": emoji,
+		"user": map[string]string{
+			"id": userID,
+		},
+	})
 	if err != nil {
 		return err
 	}
@@ -910,7 +930,12 @@ func (tc *ClientImpl) UnsetReaction(teamID, channelID, parentID, messageID, user
 		ctb := tc.client.Teams().ID(teamID).Channels().ID(channelID).Messages().ID(messageID)
 		ctb.SetURL(ctb.URL() + "/unsetReaction")
 		ct := ctb.Request()
-		req, err := ct.NewJSONRequest("POST", "", map[string]string{"reactionType": emoji})
+		req, err := ct.NewJSONRequest("POST", "", map[string]interface{}{
+			"reactionType": emoji,
+			"user": map[string]string{
+				"id": userID,
+			},
+		})
 		if err != nil {
 			return err
 		}
@@ -930,7 +955,12 @@ func (tc *ClientImpl) UnsetReaction(teamID, channelID, parentID, messageID, user
 		ctb := tc.client.Teams().ID(teamID).Channels().ID(channelID).Messages().ID(parentID).Replies().ID(messageID)
 		ctb.SetURL(ctb.URL() + "/unsetReaction")
 		ct := ctb.Request()
-		req, err := ct.NewJSONRequest("POST", "", map[string]string{"reactionType": emoji})
+		req, err := ct.NewJSONRequest("POST", "", map[string]interface{}{
+			"reactionType": emoji,
+			"user": map[string]string{
+				"id": userID,
+			},
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### Summary
- Added the logic in client functions to also send the user id along with the emoji name
- Modified the function definitions in the message hooks file
- Added another entry in the emoji map

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/32
