### PR TITLE
[MI-2992] Fixed the issue of message edits not being synced (issue #53)

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -158,12 +158,6 @@ func (p *Plugin) ReactionHasBeenRemoved(c *plugin.Context, reaction *model.React
 
 func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, newPost, oldPost *model.Post) {
 	p.API.LogDebug("Updating message hook", "newPost", newPost, "oldPost", oldPost)
-	if oldPost.Props != nil {
-		if _, ok := oldPost.Props["msteams_sync_"+p.userID].(bool); ok {
-			p.API.LogDebug("Updating a post that was created from MS Teams.")
-		}
-	}
-
 	client, err := p.GetClientForUser(newPost.UserId)
 	if err != nil {
 		return

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -160,7 +160,7 @@ func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, newPost, oldPost *mode
 	p.API.LogDebug("Updating message hook", "newPost", newPost, "oldPost", oldPost)
 	if oldPost.Props != nil {
 		if _, ok := oldPost.Props["msteams_sync_"+p.userID].(bool); ok {
-			return
+			p.API.LogDebug("Updating a post that was created from MS Teams.")
 		}
 	}
 


### PR DESCRIPTION
#### Summary
Fixed the issue of message edits not being synced

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/53