### PR TITLE
[MI-2991] Fixed the issue of incorrect bot profile picture while impersonating a user

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -57,7 +57,10 @@ func (a *API) getAvatar(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	_, _ = w.Write(photo)
+
+	if _, err := w.Write(photo); err != nil {
+		a.p.API.LogError("Unable to write the response", "Error", err.Error())
+	}
 }
 
 // processActivity handles the activity received from teams subscriptions

--- a/server/handlers/converters_test.go
+++ b/server/handlers/converters_test.go
@@ -42,7 +42,7 @@ func TestMsgToPost(t *testing.T) {
 				Props: model.StringInterface{
 					"from_webhook":                         "true",
 					"msteams_sync_pqoejrn65psweomewmosaqr": true,
-					"override_icon_url":                    "https://example.com//avatar/sfmq19kpztg5iy47ebe51hb31w",
+					"override_icon_url":                    "https://example.com//public/msteams-sync-icon.svg",
 					"override_username":                    "mock-UserDisplayName",
 				},
 				FileIds: model.StringArray{},
@@ -54,7 +54,7 @@ func TestMsgToPost(t *testing.T) {
 			testCase.setupPlugin(p)
 			ah.plugin = p
 			post, _ := ah.msgToPost(testCase.userID, testCase.channelID, testCase.message, testCase.senderID)
-			assert.Equal(t, post, testCase.post)
+			assert.Equal(t, testCase.post, post)
 		})
 	}
 }

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -145,7 +145,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetClientForTeamsUser", testutils.GetTeamUserID()).Return(client, nil).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(1)
-				p.On("GetStore").Return(store).Times(3)
+				p.On("GetStore").Return(store).Times(2)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
 			},
@@ -175,7 +175,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
 				store.On("TeamsToMattermostUserID", testutils.GetTeamUserID()).Return(testutils.GetUserID(), nil).Times(1)
 			},
 		},


### PR DESCRIPTION
#### Summary
- Added the logic of making an API call to the avatar API and checking if we get a valid profile picture or not
- Added error handling in the avatar API

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/52
