### PR TITLE
[MI-3057] Added the logic for prompting the user if he is not connected

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/enescakir/emoji"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams"
@@ -353,8 +354,16 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 
 	srcUserID, err := p.store.MattermostToTeamsUserID(srcUser)
 	if err != nil {
+		p.handlePromptForConnection(srcUser, post.ChannelId)
 		return "", err
 	}
+
+	client, err := p.GetClientForUser(srcUser)
+	if err != nil {
+		p.handlePromptForConnection(srcUser, post.ChannelId)
+		return "", err
+	}
+
 	teamsUsersIDs := make([]string, len(usersIDs))
 	for idx, userID := range usersIDs {
 		var teamsUserID string
@@ -367,11 +376,6 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 
 	p.API.LogDebug("Sending direct message to MS Teams", "srcUserID", srcUserID, "teamsUsersIDs", teamsUsersIDs, "post", post)
 	text := post.Message
-
-	client, err := p.GetClientForUser(srcUser)
-	if err != nil {
-		return "", err
-	}
 
 	chatID, err := client.CreateOrGetChatForUsers(teamsUsersIDs)
 	if err != nil {
@@ -392,6 +396,21 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		}
 	}
 	return newMessage.ID, nil
+}
+
+func (p *Plugin) handlePromptForConnection(userID, channelID string) {
+	timestamp, err := p.store.GetDMAndGMChannelPromptTime(channelID, userID)
+	if err != nil {
+		p.API.LogDebug("Unable to get the last prompt timestamp for the channel", "ChannelID", channelID, "Error", err.Error())
+	}
+
+	if time.Until(timestamp) < -time.Hour*24*30 {
+		p.sendBotEphemeralPost(userID, channelID, "Your Mattermost account is not connected to MS Teams so this message will not be relayed to users on MS Teams. You can connect your account using the `/msteams-sync connect` slash command.")
+
+		if err = p.store.StoreDMAndGMChannelPromptTime(channelID, userID, time.Now()); err != nil {
+			p.API.LogDebug("Unable to store the last prompt timestamp for the channel", "ChannelID", channelID, "Error", err.Error())
+		}
+	}
 }
 
 func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Post) (string, error) {

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -81,6 +81,27 @@ func (_m *Store) GetAvatarCache(userID string) ([]byte, error) {
 	return r0, r1
 }
 
+// GetDMAndGMChannelPromptTime provides a mock function with given fields: channelID, userID
+func (_m *Store) GetDMAndGMChannelPromptTime(channelID string, userID string) (time.Time, error) {
+	ret := _m.Called(channelID, userID)
+
+	var r0 time.Time
+	if rf, ok := ret.Get(0).(func(string, string) time.Time); ok {
+		r0 = rf(channelID, userID)
+	} else {
+		r0 = ret.Get(0).(time.Time)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(channelID, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetLinkByChannelID provides a mock function with given fields: channelID
 func (_m *Store) GetLinkByChannelID(channelID string) (*storemodels.ChannelLink, error) {
 	ret := _m.Called(channelID)
@@ -414,6 +435,20 @@ func (_m *Store) StoreChannelLink(link *storemodels.ChannelLink) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*storemodels.ChannelLink) error); ok {
 		r0 = rf(link)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// StoreDMAndGMChannelPromptTime provides a mock function with given fields: channelID, userID, timestamp
+func (_m *Store) StoreDMAndGMChannelPromptTime(channelID string, userID string, timestamp time.Time) error {
+	ret := _m.Called(channelID, userID, timestamp)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, time.Time) error); ok {
+		r0 = rf(channelID, userID, timestamp)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -19,6 +19,7 @@ import (
 const (
 	avatarCacheTime              = 300
 	avatarKey                    = "avatar_"
+	connectionPromptKey          = "connect_"
 	subscriptionRefreshTimeLimit = 5 * time.Minute
 )
 
@@ -47,6 +48,8 @@ type Store interface {
 	SaveChannelSubscription(storemodels.ChannelSubscription) error
 	UpdateSubscriptionExpiresOn(subscriptionID string, expiresOn time.Time) error
 	DeleteSubscription(subscriptionID string) error
+	StoreDMAndGMChannelPromptTime(channelID, userID string, timestamp time.Time) error
+	GetDMAndGMChannelPromptTime(channelID, userID string) (time.Time, error)
 }
 
 type SQLStore struct {
@@ -534,6 +537,33 @@ func (s *SQLStore) DeleteSubscription(subscriptionID string) error {
 		return err
 	}
 	return nil
+}
+
+func (s *SQLStore) StoreDMAndGMChannelPromptTime(channelID, userID string, timestamp time.Time) error {
+	timeBytes, err := timestamp.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	if err := s.api.KVSet(connectionPromptKey+channelID+"_"+userID, timeBytes); err != nil {
+		return errors.New(err.Error())
+	}
+
+	return nil
+}
+
+func (s *SQLStore) GetDMAndGMChannelPromptTime(channelID, userID string) (time.Time, error) {
+	var t time.Time
+	data, err := s.api.KVGet(connectionPromptKey + channelID + "_" + userID)
+	if err != nil {
+		return t, errors.New(err.Error())
+	}
+
+	if err := t.UnmarshalJSON(data); err != nil {
+		return t, err
+	}
+
+	return t, nil
 }
 
 func (s *SQLStore) CheckEnabledTeamByTeamID(teamID string) bool {


### PR DESCRIPTION
#### Summary
- Created two new store functions to store the last prompt time for a channel and user id
- Added the logic to show a prompt once per month if the user is posting in a DM or GM and is not connected
- Added new unit tests for these new functions

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/103