### PR TITLE
[MI-3085] Added the logic for re-prompting the user in DMs an GMs if he has connected and disconnected again

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -309,6 +309,10 @@ func (p *Plugin) executeDisconnectCommand(args *model.CommandArgs) (*model.Comma
 	}
 
 	p.sendBotEphemeralPost(args.UserId, args.ChannelId, "Your account has been disconnected.")
+	if err := p.store.DeleteDMAndGMChannelPromptTime(args.UserId); err != nil {
+		p.API.LogDebug("Unable to delete the last prompt timestamp for the user", "UserID", args.UserId, "Error", err.Error())
+	}
+
 	return &model.CommandResponse{}, nil
 }
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -258,12 +258,15 @@ func TestExecuteDisconnectCommand(t *testing.T) {
 					UserId:  "bot-user-id",
 					Message: "Your account has been disconnected.",
 				}).Return(testutils.GetPost("", testutils.GetUserID())).Times(1)
+
+				api.On("LogDebug", "Unable to delete the last prompt timestamp for the user", "UserID", testutils.GetUserID(), "Error", "error in deleting prompt time")
 			},
 			setupStore: func(s *mockStore.Store) {
 				s.On("MattermostToTeamsUserID", testutils.GetUserID()).Return(testutils.GetTeamUserID(), nil).Times(1)
 				s.On("GetTokenForMattermostUser", testutils.GetUserID()).Return(nil, nil).Once()
 				var token *oauth2.Token
 				s.On("SetUserInfo", testutils.GetUserID(), testutils.GetTeamUserID(), token).Return(nil).Times(1)
+				s.On("DeleteDMAndGMChannelPromptTime", testutils.GetUserID()).Return(errors.New("error in deleting prompt time")).Once()
 			},
 		},
 		{

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -30,6 +30,20 @@ func (_m *Store) CheckEnabledTeamByTeamID(teamID string) bool {
 	return r0
 }
 
+// DeleteDMAndGMChannelPromptTime provides a mock function with given fields: userID
+func (_m *Store) DeleteDMAndGMChannelPromptTime(userID string) error {
+	ret := _m.Called(userID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteLinkByChannelID provides a mock function with given fields: channelID
 func (_m *Store) DeleteLinkByChannelID(channelID string) error {
 	ret := _m.Called(channelID)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -59,6 +59,7 @@ type Store interface {
 	GetSubscriptionType(subscriptionID string) (string, error)
 	StoreDMAndGMChannelPromptTime(channelID, userID string, timestamp time.Time) error
 	GetDMAndGMChannelPromptTime(channelID, userID string) (time.Time, error)
+	DeleteDMAndGMChannelPromptTime(userID string) error
 }
 
 type SQLStore struct {
@@ -680,6 +681,37 @@ func (s *SQLStore) GetDMAndGMChannelPromptTime(channelID, userID string) (time.T
 	}
 
 	return t, nil
+}
+
+func (s *SQLStore) DeleteDMAndGMChannelPromptTime(userID string) error {
+	var userKeys []string
+	page := 0
+	perPage := 100
+	for {
+		keys, err := s.api.KVList(page, perPage)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+
+		for _, key := range keys {
+			if strings.HasPrefix(key, connectionPromptKey) && strings.Contains(key, userID) {
+				userKeys = append(userKeys, key)
+			}
+		}
+
+		if len(keys) < perPage {
+			break
+		}
+		page++
+	}
+
+	for _, key := range userKeys {
+		if err := s.api.KVDelete(key); err != nil {
+			return errors.New(err.Error())
+		}
+	}
+
+	return nil
 }
 
 func (s *SQLStore) CheckEnabledTeamByTeamID(teamID string) bool {

--- a/server/store/store_test.go
+++ b/server/store/store_test.go
@@ -130,7 +130,7 @@ func TestStore(t *testing.T) {
 		"testGetChatSubscription":                                    testGetChatSubscription,
 		"testGetChannelSubscription":                                 testGetChannelSubscription,
 		"testGetSubscriptionType":                                    testGetSubscriptionType,
-		"testStoreAndGetDMGMPromptTime":                              testStoreAndGetDMGMPromptTime,
+		"testStoreAndGetAndDeleteDMGMPromptTime":                     testStoreAndGetAndDeleteDMGMPromptTime,
 	}
 	for _, driver := range []string{model.DatabaseDriverPostgres, model.DatabaseDriverMysql} {
 		store, api, tearDownContainer := setupTestStore(&plugintest.API{}, driver)
@@ -992,17 +992,23 @@ func testGetSubscriptionType(t *testing.T, store *SQLStore, _ *plugintest.API) {
 	})
 }
 
-func testStoreAndGetDMGMPromptTime(t *testing.T, store *SQLStore, api *plugintest.API) {
+func testStoreAndGetAndDeleteDMGMPromptTime(t *testing.T, store *SQLStore, api *plugintest.API) {
 	testTime := time.Now()
-	api.On("KVSet", connectionPromptKey+"mockMattermostChannelID-1_mockMattermostUserID-1", mock.Anything).Return(nil)
+	key := connectionPromptKey + "mockMattermostChannelID-1_mockMattermostUserID-1"
+	api.On("KVSet", key, mock.Anything).Return(nil)
 	err := store.StoreDMAndGMChannelPromptTime("mockMattermostChannelID-1", "mockMattermostUserID-1", testTime)
 	assert.Nil(t, err)
 
 	timeBytes, err := testTime.MarshalJSON()
 	assert.Nil(t, err)
-	api.On("KVGet", connectionPromptKey+"mockMattermostChannelID-1_mockMattermostUserID-1").Return(timeBytes, nil)
+	api.On("KVGet", key).Return(timeBytes, nil)
 
 	timestamp, err := store.GetDMAndGMChannelPromptTime("mockMattermostChannelID-1", "mockMattermostUserID-1")
 	assert.Nil(t, err)
 	assert.True(t, timestamp.Equal(testTime))
+
+	api.On("KVList", 0, 100).Return([]string{key}, nil).Once()
+	api.On("KVDelete", key).Return(nil).Once()
+	err = store.DeleteDMAndGMChannelPromptTime("mockMattermostUserID-1")
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
#### Summary
Created a new function in the store for deleting the DM and GM channel prompt time
Added the logic for deleting the prompt time for a user when he disconnects
Fixed the failing unit tests and added some new unit tests

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/118

