### PR TITLE
[MI-3161] Fixed the issue of reactions causing infinite loop in both channels and chats

### DIFF
--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -380,7 +380,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 	}
 
 	ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
-	ah.plugin.GetAPI().LogError("Message reactions", "reactions", msg.Reactions, "error", err)
 	ah.handleReactions(postInfo.MattermostID, channelID, msg.Reactions)
 }
 
@@ -448,7 +447,7 @@ func (ah *ActivityHandler) handleReactions(postID, channelID string, reactions [
 				ah.plugin.GetAPI().LogError("failed to create the reaction", "err", appErr)
 				continue
 			}
-			ah.plugin.GetAPI().LogError("Added reaction", "reaction", r)
+			ah.plugin.GetAPI().LogDebug("Added reaction", "reaction", r)
 		}
 	}
 }

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -777,7 +777,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
 				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetClientForTeamsUser", testutils.GetTeamUserID()).Return(client, nil).Times(1)
-				p.On("GetAPI").Return(mockAPI).Times(6)
+				p.On("GetAPI").Return(mockAPI).Times(5)
 				p.On("GetStore").Return(store).Times(4)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)
@@ -805,7 +805,6 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetPost", "mockMattermostID").Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetSenderID()), nil).Times(1)
 				mockAPI.On("LogDebug", "Handling reactions", "reactions", mock.Anything).Times(1)
-				mockAPI.On("LogError", "Message reactions", "reactions", mock.Anything, "error", mock.Anything).Times(1)
 				mockAPI.On("UpdatePost", mock.Anything).Return(nil, nil).Times(1)
 				mockAPI.On("GetReactions", "mockMattermostID").Return([]*model.Reaction{}, nil).Times(1)
 			},

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -241,13 +241,12 @@ func (p *Plugin) SetChatReaction(teamsMessageID, srcUser, channelID string, emoj
 
 	teamsMessage, err := client.GetChatMessage(chatID, teamsMessageID)
 	if err != nil {
-		p.API.LogWarn("Error getting the msteams post metadata", "error", err)
+		p.API.LogWarn("Error getting the msteams post metadata", "error", err.Error())
 		return nil
 	}
 
 	if err = p.store.SetPostLastUpdateAtByMSTeamsID(teamsMessageID, teamsMessage.LastUpdateAt); err != nil {
-		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
-		return err
+		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err.Error())
 	}
 
 	return nil
@@ -294,13 +293,12 @@ func (p *Plugin) SetReaction(teamID, channelID, userID string, post *model.Post,
 		teamsMessage, err = client.GetMessage(teamID, channelID, postInfo.MSTeamsID)
 	}
 	if err != nil {
-		p.API.LogWarn("Error getting the msteams post metadata", "error", err)
+		p.API.LogWarn("Error getting the msteams post metadata", "error", err.Error())
 		return nil
 	}
 
 	if err = p.store.SetPostLastUpdateAtByMattermostID(postInfo.MattermostID, teamsMessage.LastUpdateAt); err != nil {
-		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
-		return err
+		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err.Error())
 	}
 
 	return nil
@@ -332,13 +330,12 @@ func (p *Plugin) UnsetChatReaction(teamsMessageID, srcUser, channelID string, em
 
 	teamsMessage, err := client.GetChatMessage(chatID, teamsMessageID)
 	if err != nil {
-		p.API.LogWarn("Error getting the msteams post metadata", "error", err)
+		p.API.LogWarn("Error getting the msteams post metadata", "error", err.Error())
 		return nil
 	}
 
 	if err = p.store.SetPostLastUpdateAtByMSTeamsID(teamsMessageID, teamsMessage.LastUpdateAt); err != nil {
-		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
-		return err
+		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err.Error())
 	}
 
 	return nil
@@ -385,13 +382,12 @@ func (p *Plugin) UnsetReaction(teamID, channelID, userID string, post *model.Pos
 		teamsMessage, err = client.GetMessage(teamID, channelID, postInfo.MSTeamsID)
 	}
 	if err != nil {
-		p.API.LogWarn("Error getting the msteams post metadata", "error", err)
+		p.API.LogWarn("Error getting the msteams post metadata", "error", err.Error())
 		return nil
 	}
 
 	if err = p.store.SetPostLastUpdateAtByMattermostID(postInfo.MattermostID, teamsMessage.LastUpdateAt); err != nil {
-		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
-		return err
+		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err.Error())
 	}
 
 	return nil
@@ -745,6 +741,7 @@ func (p *Plugin) GetChatIDForChannel(clientUserID string, channelID string) (str
 	return chatID, nil
 }
 
+// TODO: Add unit tests for this function
 func (p *Plugin) getMentionsData(message, teamID, channelID, chatID string, client msteams.Client) (string, []models.ChatMessageMentionable) {
 	specialMentions := map[string]bool{
 		"all":     true,

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -149,7 +149,7 @@ func (e *GraphAPIError) Error() string {
 	return fmt.Sprintf("code: %s, message: %s", e.Code, e.Message)
 }
 
-func NormalizeGraphAPIError(err error) *GraphAPIError {
+func NormalizeGraphAPIError(err error) error {
 	if err == nil {
 		return nil
 	}

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -592,6 +592,34 @@ func (_m *Store) SetAvatarCache(userID string, photo []byte) error {
 	return r0
 }
 
+// SetPostLastUpdateAtByMSTeamsID provides a mock function with given fields: postID, lastUpdateAt
+func (_m *Store) SetPostLastUpdateAtByMSTeamsID(postID string, lastUpdateAt time.Time) error {
+	ret := _m.Called(postID, lastUpdateAt)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = rf(postID, lastUpdateAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetPostLastUpdateAtByMattermostID provides a mock function with given fields: postID, lastUpdateAt
+func (_m *Store) SetPostLastUpdateAtByMattermostID(postID string, lastUpdateAt time.Time) error {
+	ret := _m.Called(postID, lastUpdateAt)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = rf(postID, lastUpdateAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetUserInfo provides a mock function with given fields: userID, msTeamsUserID, token
 func (_m *Store) SetUserInfo(userID string, msTeamsUserID string, token *oauth2.Token) error {
 	ret := _m.Called(userID, msTeamsUserID, token)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -40,6 +40,8 @@ type Store interface {
 	GetPostInfoByMSTeamsID(chatID string, postID string) (*storemodels.PostInfo, error)
 	GetPostInfoByMattermostID(postID string) (*storemodels.PostInfo, error)
 	LinkPosts(postInfo storemodels.PostInfo) error
+	SetPostLastUpdateAtByMattermostID(postID string, lastUpdateAt time.Time) error
+	SetPostLastUpdateAtByMSTeamsID(postID string, lastUpdateAt time.Time) error
 	GetTokenForMattermostUser(userID string) (*oauth2.Token, error)
 	GetTokenForMSTeamsUser(userID string) (*oauth2.Token, error)
 	SetUserInfo(userID string, msTeamsUserID string, token *oauth2.Token) error
@@ -410,6 +412,24 @@ func (s *SQLStore) GetPostInfoByMattermostID(postID string) (*storemodels.PostIn
 	}
 	postInfo.MSTeamsLastUpdateAt = time.UnixMicro(lastUpdateAt)
 	return &postInfo, nil
+}
+
+func (s *SQLStore) SetPostLastUpdateAtByMattermostID(postID string, lastUpdateAt time.Time) error {
+	query := s.getQueryBuilder().Update("msteamssync_posts").Set("msTeamsLastUpdateAt", lastUpdateAt.UnixMicro()).Where(sq.Eq{"mmPostID": postID})
+	if _, err := query.Exec(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SQLStore) SetPostLastUpdateAtByMSTeamsID(msTeamsPostID string, lastUpdateAt time.Time) error {
+	query := s.getQueryBuilder().Update("msteamssync_posts").Set("msTeamsLastUpdateAt", lastUpdateAt.UnixMicro()).Where(sq.Eq{"msTeamsPostID": msTeamsPostID})
+	if _, err := query.Exec(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *SQLStore) LinkPosts(postInfo storemodels.PostInfo) error {


### PR DESCRIPTION
#### Summary
- Created two new store functions for updating last post updateAt time by both MM post id and MS Teams post id
- Modified the return type of error handling function and modified some logs
- Added the logic of updating post last updateAt time when reactions are updated in MM

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/165
