### PR TITLE
[MI-3165] Add support to send attachments in DMs and GMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/testcontainers/testcontainers-go v0.19.0
 	gitlab.com/golang-commonmark/markdown v0.0.0-20211110145824-bf3e522c626a
+	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )
 
@@ -113,7 +114,6 @@ require (
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -209,14 +208,12 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 		return
 	}
 
-	fmt.Println("1")
 	msteamsUserID, _ := ah.plugin.GetStore().MattermostToTeamsUserID(ah.plugin.GetBotUserID())
 	if msg.UserID == msteamsUserID {
 		ah.plugin.GetAPI().LogDebug("Skipping messages from bot user")
 		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		return
 	}
-	fmt.Println("2", chat, msg, " fer")
 
 	var senderID string
 	var channelID string
@@ -244,14 +241,10 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 		senderID = ah.plugin.GetBotUserID()
 	}
 
-	fmt.Println("3", channelID, " fref")
-
 	if channelID == "" {
 		ah.plugin.GetAPI().LogDebug("Channel not set")
 		return
 	}
-
-	fmt.Println("4")
 
 	var userID string
 	if msg.TeamID != "" && msg.ChannelID != "" {
@@ -263,8 +256,6 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 		}
 	}
 
-	fmt.Println("5")
-
 	post, err := ah.msgToPost(userID, channelID, msg, senderID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to transform teams post in mattermost post", "message", msg, "error", err)
@@ -273,8 +264,6 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 
 	ah.plugin.GetAPI().LogDebug("Post generated", "post", post)
 
-	fmt.Println("6")
-
 	// Avoid possible duplication
 	postInfo, _ := ah.plugin.GetStore().GetPostInfoByMSTeamsID(msg.ChatID+msg.ChannelID, msg.ID)
 	if postInfo != nil {
@@ -282,10 +271,8 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		return
 	}
-	fmt.Println("7")
 
 	newPost, appErr := ah.plugin.GetAPI().CreatePost(post)
-	fmt.Println("9", newPost, appErr)
 
 	if appErr != nil {
 		ah.plugin.GetAPI().LogError("Unable to create post", "post", post, "error", appErr)
@@ -293,7 +280,6 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 	}
 
 	ah.plugin.GetAPI().LogDebug("Post created", "post", newPost)
-	fmt.Println("10")
 
 	ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 	if newPost != nil && newPost.Id != "" && msg.ID != "" {

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -311,8 +311,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 		return
 	}
 
-	fmt.Println("1")
-
 	if msg == nil {
 		ah.plugin.GetAPI().LogDebug("Unable to get the message (probably because belongs to private chat in not-linked users)")
 		return
@@ -323,8 +321,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 		return
 	}
 
-	fmt.Println("2")
-
 	msteamsUserID, _ := ah.plugin.GetStore().MattermostToTeamsUserID(ah.plugin.GetBotUserID())
 	if msg.UserID == msteamsUserID {
 		ah.plugin.GetAPI().LogDebug("Skipping messages from bot user")
@@ -332,22 +328,17 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 		return
 	}
 
-	fmt.Println("3")
-
 	postInfo, _ := ah.plugin.GetStore().GetPostInfoByMSTeamsID(msg.ChatID+msg.ChannelID, msg.ID)
 	if postInfo == nil {
 		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		return
 	}
 
-	fmt.Println("4")
-
 	// Ignore if the change is already applied in the database
 	if postInfo.MSTeamsLastUpdateAt.UnixMicro() == msg.LastUpdateAt.UnixMicro() {
 		return
 	}
 
-	fmt.Println("5")
 	channelID := ""
 	if chat == nil {
 		var channelLink *storemodels.ChannelLink
@@ -378,14 +369,10 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 		channelID = post.ChannelId
 	}
 
-	fmt.Println("5")
-
 	senderID, err := ah.plugin.GetStore().TeamsToMattermostUserID(msg.UserID)
 	if err != nil || senderID == "" {
 		senderID = ah.plugin.GetBotUserID()
 	}
-
-	fmt.Println("6")
 
 	var userID string
 	if msg.TeamID != "" && msg.ChannelID != "" {
@@ -397,8 +384,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 		}
 	}
 
-	fmt.Println("7")
-
 	post, err := ah.msgToPost(userID, channelID, msg, senderID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to transform teams post in mattermost post", "message", msg, "error", err)
@@ -406,7 +391,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 	}
 
 	post.Id = postInfo.MattermostID
-	fmt.Println("8")
 
 	if _, appErr := ah.plugin.GetAPI().UpdatePost(post); appErr != nil {
 		if strings.EqualFold(appErr.Id, "app.post.get.app_error") {
@@ -419,7 +403,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 			return
 		}
 	}
-	fmt.Println("9")
 
 	ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 	ah.plugin.GetAPI().LogError("Message reactions", "reactions", msg.Reactions, "error", err)

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -275,7 +275,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(&storemodels.PostInfo{}, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetMSTeamsChannelID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{}, nil).Times(1)
 			},
 		},
 		{
@@ -321,22 +321,14 @@ func TestHandleCreatedActivity(t *testing.T) {
 				mockAPI.On("GetDirectChannel", "mockUserID-1", "mockUserID-2").Return(&model.Channel{
 					Id: testutils.GetChannelID(),
 				}, nil).Times(1)
-				mockAPI.On("CreatePost", &model.Post{
-					UserId:    testutils.GetUserID(),
-					ChannelId: testutils.GetChannelID(),
-					Message:   "mockText",
-					Props: model.StringInterface{
-						"msteams_sync_mock-BotUserID": true,
-					},
-					FileIds: model.StringArray{},
-				}).Return(nil, testutils.GetInternalServerAppError("unable to create the post")).Times(1)
+				mockAPI.On("CreatePost", testutils.GetPostFromTeamsMessage()).Return(nil, testutils.GetInternalServerAppError("unable to create the post")).Times(1)
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
 				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetMSTeamsChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
 			},
 		},
 		{
@@ -383,26 +375,18 @@ func TestHandleCreatedActivity(t *testing.T) {
 				mockAPI.On("GetDirectChannel", "mockUserID-1", "mockUserID-2").Return(&model.Channel{
 					Id: testutils.GetChannelID(),
 				}, nil).Times(1)
-				mockAPI.On("CreatePost", &model.Post{
-					UserId:    testutils.GetUserID(),
-					ChannelId: testutils.GetChannelID(),
-					Message:   "mockText",
-					Props: model.StringInterface{
-						"msteams_sync_mock-BotUserID": true,
-					},
-					FileIds: model.StringArray{},
-				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
+				mockAPI.On("CreatePost", testutils.GetPostFromTeamsMessage()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
 				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetMSTeamsChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
 				store.On("LinkPosts", storemodels.PostInfo{
 					MattermostID:   testutils.GetID(),
 					MSTeamsID:      testutils.GetMessageID(),
-					MSTeamsChannel: "qplsnwere9nurernidteoqw",
+					MSTeamsChannel: testutils.GetMSTeamsChannelID(),
 				}).Return(errors.New("unable to update the post")).Times(1)
 			},
 		},
@@ -449,26 +433,18 @@ func TestHandleCreatedActivity(t *testing.T) {
 				mockAPI.On("GetDirectChannel", "mockUserID-1", "mockUserID-2").Return(&model.Channel{
 					Id: testutils.GetChannelID(),
 				}, nil).Times(1)
-				mockAPI.On("CreatePost", &model.Post{
-					UserId:    testutils.GetUserID(),
-					ChannelId: testutils.GetChannelID(),
-					Message:   "mockText",
-					Props: model.StringInterface{
-						"msteams_sync_mock-BotUserID": true,
-					},
-					FileIds: model.StringArray{},
-				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
+				mockAPI.On("CreatePost", testutils.GetPostFromTeamsMessage()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
 				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetMSTeamsChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
 				store.On("LinkPosts", storemodels.PostInfo{
 					MattermostID:   testutils.GetID(),
 					MSTeamsID:      testutils.GetMessageID(),
-					MSTeamsChannel: "qplsnwere9nurernidteoqw",
+					MSTeamsChannel: testutils.GetMSTeamsChannelID(),
 				}).Return(nil).Times(1)
 			},
 		},
@@ -500,15 +476,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				mockAPI.On("LogDebug", "Post generated", "post", mock.Anything).Times(1)
 				mockAPI.On("LogDebug", "Post created", "post", mock.Anything).Times(1)
 				mockAPI.On("GetUserByEmail", mock.AnythingOfType("string")).Return(testutils.GetUser(model.ChannelAdminRoleId, "test@test.com")).Times(2)
-				mockAPI.On("CreatePost", &model.Post{
-					UserId:    testutils.GetUserID(),
-					ChannelId: testutils.GetChannelID(),
-					Message:   "mockText",
-					Props: model.StringInterface{
-						"msteams_sync_mock-BotUserID": true,
-					},
-					FileIds: model.StringArray{},
-				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
+				mockAPI.On("CreatePost", testutils.GetPostFromTeamsMessage()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -823,7 +823,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
 				p.On("GetClientForUser", "mockCreator").Return(client, nil).Times(1)
-				p.On("GetAPI").Return(mockAPI).Times(5)
+				p.On("GetAPI").Return(mockAPI).Times(4)
 				p.On("GetStore").Return(store).Times(6)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -164,8 +164,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					TeamID:          "mockTeamID",
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -211,8 +209,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					TeamID:          "mockTeamID",
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -261,8 +257,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					TeamID:          "mockTeamID",
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -278,13 +272,10 @@ func TestHandleCreatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mockCreator",
-				}, nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqwbnqnzipmnir4zkkj95ggba5pde", testutils.GetMessageID()).Return(&storemodels.PostInfo{}, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(&storemodels.PostInfo{}, nil).Times(1)
 			},
 		},
 		{
@@ -318,8 +309,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					TeamID:          "mockTeamID",
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -344,13 +333,10 @@ func TestHandleCreatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mockCreator",
-				}, nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqwbnqnzipmnir4zkkj95ggba5pde", testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(nil, nil).Times(1)
 			},
 		},
 		{
@@ -384,8 +370,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					TeamID:          "mockTeamID",
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -411,22 +395,19 @@ func TestHandleCreatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mockCreator",
-				}, nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqwbnqnzipmnir4zkkj95ggba5pde", testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(nil, nil).Times(1)
 				store.On("LinkPosts", storemodels.PostInfo{
 					MattermostID:   testutils.GetID(),
 					MSTeamsID:      testutils.GetMessageID(),
-					MSTeamsChannel: "qplsnwere9nurernidteoqwbnqnzipmnir4zkkj95ggba5pde",
+					MSTeamsChannel: "qplsnwere9nurernidteoqw",
 				}).Return(errors.New("unable to update the post")).Times(1)
 			},
 		},
 		{
-			description: "Valid",
+			description: "Valid: chat message",
 			activityIds: msteams.ActivityIds{
 				ChatID:    testutils.GetChatID(),
 				MessageID: testutils.GetMessageID(),
@@ -456,8 +437,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					TeamID:          "mockTeamID",
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -482,18 +461,71 @@ func TestHandleCreatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(2)
 				store.On("TeamsToMattermostUserID", "mockUserID-1").Return("mockUserID-1", nil).Times(1)
 				store.On("TeamsToMattermostUserID", "mockUserID-2").Return("mockUserID-2", nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mockCreator",
-				}, nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqwbnqnzipmnir4zkkj95ggba5pde", testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", "qplsnwere9nurernidteoqw", testutils.GetMessageID()).Return(nil, nil).Times(1)
 				store.On("LinkPosts", storemodels.PostInfo{
 					MattermostID:   testutils.GetID(),
 					MSTeamsID:      testutils.GetMessageID(),
-					MSTeamsChannel: "qplsnwere9nurernidteoqwbnqnzipmnir4zkkj95ggba5pde",
+					MSTeamsChannel: "qplsnwere9nurernidteoqw",
 				}).Return(nil).Times(1)
+			},
+		},
+		{
+			description: "Valid: channel message",
+			activityIds: msteams.ActivityIds{
+				TeamID:    "mockTeamID",
+				ChannelID: testutils.GetChannelID(),
+				MessageID: testutils.GetMessageID(),
+			},
+			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
+				p.On("GetClientForUser", "mockCreator").Return(client, nil).Times(1)
+				p.On("GetAPI").Return(mockAPI).Times(4)
+				p.On("GetStore").Return(store).Times(7)
+				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
+			},
+			setupClient: func(client *mocksClient.Client) {
+				client.On("GetMessage", "mockTeamID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&msteams.Message{
+					ID:              testutils.GetMessageID(),
+					UserID:          testutils.GetSenderID(),
+					TeamID:          "mockTeamID",
+					ChannelID:       testutils.GetChannelID(),
+					UserDisplayName: "mockUserDisplayName",
+					Text:            "mockText",
+				}, nil).Times(1)
+			},
+			setupAPI: func(mockAPI *plugintest.API) {
+				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)
+				mockAPI.On("LogDebug", "Post generated", "post", mock.Anything).Times(1)
+				mockAPI.On("LogDebug", "Post created", "post", mock.Anything).Times(1)
+				mockAPI.On("GetUserByEmail", mock.AnythingOfType("string")).Return(testutils.GetUser(model.ChannelAdminRoleId, "test@test.com")).Times(2)
+				mockAPI.On("CreatePost", &model.Post{
+					UserId:    testutils.GetUserID(),
+					ChannelId: testutils.GetChannelID(),
+					Message:   "mockText",
+					Props: model.StringInterface{
+						"msteams_sync_mock-BotUserID": true,
+					},
+					FileIds: model.StringArray{},
+				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
+			},
+			setupStore: func(store *mocksStore.Store) {
+				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					Creator: "mockCreator",
+				}, nil).Times(1)
+				store.On("LinkPosts", storemodels.PostInfo{
+					MattermostID:   testutils.GetID(),
+					MSTeamsID:      testutils.GetMessageID(),
+					MSTeamsChannel: testutils.GetChannelID(),
+				}).Return(nil).Times(1)
+				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					Creator:             "mockCreator",
+					MattermostChannelID: testutils.GetChannelID(),
+				}, nil).Times(2)
 			},
 		},
 	} {
@@ -662,7 +694,6 @@ func TestHandleUpdatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -670,7 +701,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			setupAPI: func(mockAPI *plugintest.API) {},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID()+testutils.GetChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
 			},
 		},
 		{
@@ -700,7 +731,6 @@ func TestHandleUpdatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -711,7 +741,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID()+testutils.GetChannelID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
+				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
 					MattermostID:        "mockMattermostID",
 					MSTeamsID:           "mockMSTeamsID",
 					MSTeamsChannel:      "mockMSTeamsChannel",
@@ -746,7 +776,6 @@ func TestHandleUpdatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					ChannelID:       testutils.GetChannelID(),
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -759,7 +788,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID()+testutils.GetChannelID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
+				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
 					MattermostID:        "mockMattermostID",
 					MSTeamsID:           "mockMSTeamsID",
 					MSTeamsChannel:      "mockMSTeamsChannel",
@@ -769,7 +798,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			},
 		},
 		{
-			description: "Valid",
+			description: "Valid: chat message",
 			activityIds: msteams.ActivityIds{
 				ChatID:    testutils.GetChatID(),
 				MessageID: testutils.GetMessageID(),
@@ -796,8 +825,6 @@ func TestHandleUpdatedActivity(t *testing.T) {
 					ID:              testutils.GetMessageID(),
 					UserID:          testutils.GetSenderID(),
 					ChatID:          testutils.GetChatID(),
-					ChannelID:       testutils.GetChannelID(),
-					TeamID:          "mockTeamID",
 					UserDisplayName: "mockUserDisplayName",
 					Text:            "mockText",
 				}, nil).Times(1)
@@ -811,16 +838,62 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			},
 			setupStore: func(store *mocksStore.Store) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID()+testutils.GetChannelID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
+				store.On("GetPostInfoByMSTeamsID", testutils.GetChatID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
 					MattermostID:        "mockMattermostID",
 					MSTeamsID:           "mockMSTeamsID",
 					MSTeamsChannel:      "mockMSTeamsChannel",
 					MSTeamsLastUpdateAt: time.Now(),
 				}, nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetTeamUserID(), nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mock-creator",
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetTeamUserID(), nil).Times(2)
+			},
+		},
+		{
+			description: "Valid: channel message",
+			activityIds: msteams.ActivityIds{
+				TeamID:    "mockTeamID",
+				ChannelID: testutils.GetChannelID(),
+				MessageID: testutils.GetMessageID(),
+			},
+			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
+				p.On("GetClientForUser", "mockCreator").Return(client, nil).Times(1)
+				p.On("GetAPI").Return(mockAPI).Times(5)
+				p.On("GetStore").Return(store).Times(6)
+				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
+				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)
+				p.On("GetBotUserID").Return(testutils.GetSenderID()).Times(2)
+				p.On("GetSyncDirectMessages").Return(true).Times(1)
+			},
+			setupClient: func(client *mocksClient.Client) {
+				client.On("GetMessage", "mockTeamID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&msteams.Message{
+					ID:              testutils.GetMessageID(),
+					UserID:          testutils.GetSenderID(),
+					TeamID:          "mockTeamID",
+					ChannelID:       testutils.GetChannelID(),
+					UserDisplayName: "mockUserDisplayName",
+					Text:            "mockText",
 				}, nil).Times(1)
+			},
+			setupAPI: func(mockAPI *plugintest.API) {
+				mockAPI.On("GetPost", "mockMattermostID").Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetSenderID()), nil).Times(1)
+				mockAPI.On("LogDebug", "Handling reactions", "reactions", mock.Anything).Times(1)
+				mockAPI.On("LogError", "Message reactions", "reactions", mock.Anything, "error", mock.Anything).Times(1)
+				mockAPI.On("UpdatePost", mock.Anything).Return(nil, nil).Times(1)
+				mockAPI.On("GetReactions", "mockMattermostID").Return([]*model.Reaction{}, nil).Times(1)
+			},
+			setupStore: func(store *mocksStore.Store) {
+				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				store.On("GetPostInfoByMSTeamsID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
+					MSTeamsLastUpdateAt: time.Now(),
+					MattermostID:        "mockMattermostID",
+				}, nil).Times(1)
+				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					Creator: "mockCreator",
+				}, nil).Times(1)
+				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					Creator:             "mockCreator",
+					MattermostChannelID: testutils.GetChannelID(),
+				}, nil).Times(2)
 			},
 		},
 	} {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -368,7 +368,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		}
 
 		var attachment *msteams.Attachment
-		attachment, err = client.UploadFile("", "", chatID, fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
+		attachment, err = client.UploadFile("", "", fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
 			p.API.LogWarn("Error in uploading attachment", "error", err)
 			continue
@@ -446,7 +446,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		}
 
 		var attachment *msteams.Attachment
-		attachment, err = client.UploadFile(teamID, channelID, "", fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
+		attachment, err = client.UploadFile(teamID, channelID, fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
 			p.API.LogWarn("error uploading attachment", "error", err)
 			continue

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -18,37 +18,6 @@ import (
 	"gitlab.com/golang-commonmark/markdown"
 )
 
-func (p *Plugin) MessageWillBePosted(_ *plugin.Context, post *model.Post) (*model.Post, string) {
-	if len(post.FileIds) > 0 && p.configuration.SyncDirectMessages {
-		channel, err := p.API.GetChannel(post.ChannelId)
-		if err != nil {
-			return post, ""
-		}
-		if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-			members, err := p.API.GetChannelMembers(channel.Id, 0, math.MaxInt32)
-			if err != nil {
-				return post, ""
-			}
-			for _, member := range members {
-				user, err := p.API.GetUser(member.UserId)
-				if err != nil {
-					return post, ""
-				}
-
-				if user.RemoteId != nil && strings.Contains(user.Username, "msteams") {
-					p.API.SendEphemeralPost(post.UserId, &model.Post{
-						Message:   "Attachments not supported in direct messages with MSTeams members",
-						UserId:    p.userID,
-						ChannelId: channel.Id,
-					})
-					return nil, "Attachments not supported in direct messages with MSTeams members"
-				}
-			}
-		}
-	}
-	return post, ""
-}
-
 func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 	p.API.LogDebug("Create message hook", "post", post)
 	if post.Props != nil {
@@ -385,12 +354,34 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		return "", err
 	}
 
+	var attachments []*msteams.Attachment
+	for _, fileID := range post.FileIds {
+		fileInfo, appErr := p.API.GetFileInfo(fileID)
+		if appErr != nil {
+			p.API.LogWarn("Unable to get file attachment", "error", appErr)
+			continue
+		}
+		fileData, appErr := p.API.GetFile(fileInfo.Id)
+		if appErr != nil {
+			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
+			continue
+		}
+
+		var attachment *msteams.Attachment
+		attachment, err = client.UploadFile("", "", chatID, fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
+		if err != nil {
+			p.API.LogWarn("Error in uploading attachment", "error", err)
+			continue
+		}
+		attachments = append(attachments, attachment)
+	}
+
 	md := markdown.New(markdown.XHTMLOutput(true))
 	content := md.RenderToString([]byte(emoji.Parse(text)))
 
 	content, mentions := p.getMentionsData(content, "", "", chatID, client)
 
-	newMessage, err := client.SendChat(chatID, parentID, content, mentions)
+	newMessage, err := client.SendChat(chatID, parentID, content, attachments, mentions)
 	if err != nil {
 		p.API.LogWarn("Error creating post", "error", err.Error())
 		return "", err
@@ -455,7 +446,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		}
 
 		var attachment *msteams.Attachment
-		attachment, err = client.UploadFile(teamID, channelID, fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
+		attachment, err = client.UploadFile(teamID, channelID, "", fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
 			p.API.LogWarn("error uploading attachment", "error", err)
 			continue

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -358,7 +358,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 	for _, fileID := range post.FileIds {
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
-			p.API.LogWarn("Unable to get file attachment", "error", appErr)
+			p.API.LogWarn("Unable to get file info", "error", appErr)
 			continue
 		}
 		fileData, appErr := p.API.GetFile(fileInfo.Id)
@@ -370,7 +370,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		var attachment *msteams.Attachment
 		attachment, err = client.UploadFile("", "", fileInfo.Name+"_"+fileInfo.Id, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
-			p.API.LogWarn("Error in uploading attachment", "error", err)
+			p.API.LogWarn("Error in uploading file attachment to Teams", "error", err)
 			continue
 		}
 		attachments = append(attachments, attachment)
@@ -436,19 +436,19 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 	for _, fileID := range post.FileIds {
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
-			p.API.LogWarn("Unable to get file attachment", "error", appErr)
+			p.API.LogWarn("Unable to get file info", "error", appErr)
 			continue
 		}
 		fileData, appErr := p.API.GetFile(fileInfo.Id)
 		if appErr != nil {
-			p.API.LogWarn("error get file attachment from mattermost", "error", appErr)
+			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
 			continue
 		}
 
 		var attachment *msteams.Attachment
 		attachment, err = client.UploadFile(teamID, channelID, fileInfo.Name+"_"+fileInfo.Id, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
-			p.API.LogWarn("error uploading attachment", "error", err)
+			p.API.LogWarn("Error in uploading file attachment to Teams", "error", err)
 			continue
 		}
 		attachments = append(attachments, attachment)

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -368,7 +368,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		}
 
 		var attachment *msteams.Attachment
-		attachment, err = client.UploadFile("", "", fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
+		attachment, err = client.UploadFile("", "", fileInfo.Name+"_"+fileInfo.Id, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
 			p.API.LogWarn("Error in uploading attachment", "error", err)
 			continue
@@ -446,7 +446,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		}
 
 		var attachment *msteams.Attachment
-		attachment, err = client.UploadFile(teamID, channelID, fileInfo.Id+"_"+fileInfo.Name, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
+		attachment, err = client.UploadFile(teamID, channelID, fileInfo.Name+"_"+fileInfo.Id, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData))
 		if err != nil {
 			p.API.LogWarn("error uploading attachment", "error", err)
 			continue

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -827,12 +827,7 @@ func TestSendChat(t *testing.T) {
 			Name: "SendChat: Unable to send the chat",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogWarn", "Error creating post", "error", mock.Anything)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -841,7 +836,7 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
 				uclient.On("CreateOrGetChatForUsers", mock.Anything).Return("mockChatID", nil).Times(1)
-				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", "", "", "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{{
@@ -854,12 +849,7 @@ func TestSendChat(t *testing.T) {
 			Name: "SendChat: Able to send the chat and not able to store the post",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogWarn", "Error updating the msteams/mattermost post link metadata", "error", mock.Anything)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -878,7 +868,7 @@ func TestSendChat(t *testing.T) {
 				}}, []models.ChatMessageMentionable{}).Return(&msteams.Message{
 					ID: "mockMessageID",
 				}, nil).Times(1)
-				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", "", "", "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 			},
@@ -887,7 +877,7 @@ func TestSendChat(t *testing.T) {
 		{
 			Name: "SendChat: Unable to get the file info",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Unable to get file attachment", "error", mock.Anything)
+				api.On("LogWarn", "Unable to get file info", "error", mock.Anything)
 				api.On("GetFileInfo", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get file attachment")).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -911,12 +901,7 @@ func TestSendChat(t *testing.T) {
 			Name: "SendChat: Unable to get the file attachment from Mattermost",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogWarn", "Error in getting file attachment from Mattermost", "error", mock.Anything)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get the file attachment from Mattermost")).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -939,13 +924,8 @@ func TestSendChat(t *testing.T) {
 		{
 			Name: "SendChat: Unable to upload the attachments",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error in uploading attachment", "error", mock.Anything)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("LogWarn", "Error in uploading file attachment to Teams", "error", mock.Anything)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -962,19 +942,14 @@ func TestSendChat(t *testing.T) {
 				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", ([]*msteams.Attachment)(nil), []models.ChatMessageMentionable{}).Return(&msteams.Message{
 					ID: "mockMessageID",
 				}, nil).Times(1)
-				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(nil, errors.New("error in uploading attachment")).Times(1)
+				uclient.On("UploadFile", "", "", "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(nil, errors.New("error in uploading attachment")).Times(1)
 			},
 			ExpectedMessage: "mockMessageID",
 		},
 		{
 			Name: "SendChat: Valid",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -988,7 +963,7 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
 				uclient.On("CreateOrGetChatForUsers", mock.Anything).Return("mockChatID", nil).Times(1)
-				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", "", "", "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{{
@@ -1042,7 +1017,7 @@ func TestSend(t *testing.T) {
 		{
 			Name: "Send: Unable to get the file info",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Unable to get file attachment", "error", mock.Anything).Times(1)
+				api.On("LogWarn", "Unable to get file info", "error", mock.Anything).Times(1)
 				api.On("GetFileInfo", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get file attachment")).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -1063,13 +1038,8 @@ func TestSend(t *testing.T) {
 		{
 			Name: "Send: Unable to get file attachment from Mattermost",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "error get file attachment from mattermost", "error", mock.Anything).Times(1)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("LogWarn", "Error in getting file attachment from Mattermost", "error", mock.Anything).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get the file attachment from Mattermost")).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -1091,19 +1061,14 @@ func TestSend(t *testing.T) {
 			Name: "Send: Unable to send message with attachments",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogWarn", "Error creating post", "error", mock.Anything).Times(1)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetTokenForMattermostUser", testutils.GetID()).Return(&oauth2.Token{}, nil).Times(1)
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
-				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendMessageWithAttachments", testutils.GetID(), testutils.GetChannelID(), "", "<p>mockMessage</p>\n", []*msteams.Attachment{
@@ -1118,12 +1083,7 @@ func TestSend(t *testing.T) {
 			Name: "Send: Able to send message with attachments but unable to store posts",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogWarn", "Error updating the msteams/mattermost post link metadata", "error", mock.Anything).Times(1)
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -1135,7 +1095,7 @@ func TestSend(t *testing.T) {
 				}).Return(errors.New("unable to store posts")).Times(1)
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
-				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendMessageWithAttachments", testutils.GetID(), testutils.GetChannelID(), "", "<p>mockMessage</p>\n", []*msteams.Attachment{
@@ -1151,12 +1111,7 @@ func TestSend(t *testing.T) {
 		{
 			Name: "Send: Able to send message with attachments with no error",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("GetFileInfo", testutils.GetID()).Return(&model.FileInfo{
-					Id:       testutils.GetID(),
-					Name:     "mockFileName",
-					Size:     1,
-					MimeType: "mockMimeType",
-				}, nil).Times(1)
+				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -1168,7 +1123,7 @@ func TestSend(t *testing.T) {
 				}).Return(nil).Times(1)
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
-				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), "mockFileName"+"_"+testutils.GetID(), 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendMessageWithAttachments", testutils.GetID(), testutils.GetChannelID(), "", "<p>mockMessage</p>\n", []*msteams.Attachment{

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -841,7 +841,7 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
 				uclient.On("CreateOrGetChatForUsers", mock.Anything).Return("mockChatID", nil).Times(1)
-				uclient.On("UploadFile", "", "", "mockChatID", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{&msteams.Attachment{
@@ -878,7 +878,7 @@ func TestSendChat(t *testing.T) {
 				}}, []models.ChatMessageMentionable{}).Return(&msteams.Message{
 					ID: "mockMessageID",
 				}, nil).Times(1)
-				uclient.On("UploadFile", "", "", "mockChatID", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 			},
@@ -962,7 +962,7 @@ func TestSendChat(t *testing.T) {
 				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", ([]*msteams.Attachment)(nil), []models.ChatMessageMentionable{}).Return(&msteams.Message{
 					ID: "mockMessageID",
 				}, nil).Times(1)
-				uclient.On("UploadFile", "", "", "mockChatID", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(nil, errors.New("error in uploading attachment")).Times(1)
+				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(nil, errors.New("error in uploading attachment")).Times(1)
 			},
 			ExpectedMessage: "mockMessageID",
 		},
@@ -988,7 +988,7 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
 				uclient.On("CreateOrGetChatForUsers", mock.Anything).Return("mockChatID", nil).Times(1)
-				uclient.On("UploadFile", "", "", "mockChatID", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{&msteams.Attachment{
@@ -1103,7 +1103,7 @@ func TestSend(t *testing.T) {
 				store.On("GetTokenForMattermostUser", testutils.GetID()).Return(&oauth2.Token{}, nil).Times(1)
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
-				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendMessageWithAttachments", testutils.GetID(), testutils.GetChannelID(), "", "<p>mockMessage</p>\n", []*msteams.Attachment{
@@ -1135,7 +1135,7 @@ func TestSend(t *testing.T) {
 				}).Return(errors.New("unable to store posts")).Times(1)
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
-				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendMessageWithAttachments", testutils.GetID(), testutils.GetChannelID(), "", "<p>mockMessage</p>\n", []*msteams.Attachment{
@@ -1168,7 +1168,7 @@ func TestSend(t *testing.T) {
 				}).Return(nil).Times(1)
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
-				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
+				uclient.On("UploadFile", testutils.GetID(), testutils.GetChannelID(), testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
 				uclient.On("SendMessageWithAttachments", testutils.GetID(), testutils.GetChannelID(), "", "<p>mockMessage</p>\n", []*msteams.Attachment{

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -844,7 +844,7 @@ func TestSendChat(t *testing.T) {
 				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
-				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{&msteams.Attachment{
+				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{{
 					ID: testutils.GetID(),
 				}}, []models.ChatMessageMentionable{}).Return(nil, errors.New("unable to send the chat")).Times(1)
 			},
@@ -873,7 +873,7 @@ func TestSendChat(t *testing.T) {
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
 				uclient.On("CreateOrGetChatForUsers", mock.Anything).Return("mockChatID", nil).Times(1)
-				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{&msteams.Attachment{
+				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{{
 					ID: testutils.GetID(),
 				}}, []models.ChatMessageMentionable{}).Return(&msteams.Message{
 					ID: "mockMessageID",
@@ -991,7 +991,7 @@ func TestSendChat(t *testing.T) {
 				uclient.On("UploadFile", "", "", testutils.GetID()+"_"+"mockFileName", 1, "mockMimeType", bytes.NewReader([]byte("mockData"))).Return(&msteams.Attachment{
 					ID: testutils.GetID(),
 				}, nil).Times(1)
-				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{&msteams.Attachment{
+				uclient.On("SendChat", "mockChatID", "", "<p>mockMessage</p>\n", []*msteams.Attachment{{
 					ID: testutils.GetID(),
 				}}, []models.ChatMessageMentionable{}).Return(&msteams.Message{
 					ID: "mockMessageID",

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -445,7 +445,7 @@ func (tc *ClientImpl) SendChat(chatID, parentID, message string, attachments []*
 	return convertToMessage(res, "", "", chatID), nil
 }
 
-func (tc *ClientImpl) UploadFile(teamID, channelID, chatID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error) {
+func (tc *ClientImpl) UploadFile(teamID, channelID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error) {
 	driveID := ""
 	itemID := ""
 	if teamID != "" && channelID != "" {

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -463,12 +463,12 @@ func (tc *ClientImpl) UploadFile(teamID, channelID, filename string, filesize in
 		}
 
 		driveID = *drive.GetId()
-		item, err := tc.client.DrivesById(driveID).Root().Get(tc.ctx, nil)
+		rootDirectory, err := tc.client.DrivesById(driveID).Root().Get(tc.ctx, nil)
 		if err != nil {
 			return nil, NormalizeGraphAPIError(err)
 		}
 
-		itemID = *item.GetId() + ":/" + filename + ":"
+		itemID = *rootDirectory.GetId() + ":/" + filename + ":"
 	}
 
 	uploadSession, err := tc.client.DrivesById(driveID).ItemsById(itemID).CreateUploadSession().Post(tc.ctx, nil, nil)

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -423,7 +423,7 @@ func (tc *ClientImpl) SendChat(chatID, parentID, message string, attachments []*
 		attachment.SetContentUrl(&att.ContentURL)
 		attachment.SetName(&att.Name)
 		msteamsAttachments = append(msteamsAttachments, attachment)
-		message = "<attachment id=\"" + att.ID + "\"></attachment>" + message
+		message = fmt.Sprintf("<attachment id=%q></attachment> %s", att.ID, message)
 	}
 
 	rmsg.SetAttachments(msteamsAttachments)
@@ -471,7 +471,6 @@ func (tc *ClientImpl) UploadFile(teamID, channelID, chatID, filename string, fil
 		itemID = *item.GetId() + ":/" + filename + ":"
 	}
 
-	fmt.Println("\n\n item id ", itemID)
 	uploadSession, err := tc.client.DrivesById(driveID).ItemsById(itemID).CreateUploadSession().Post(tc.ctx, nil, nil)
 	if err != nil {
 		return nil, NormalizeGraphAPIError(err)

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -385,11 +385,48 @@ func (tc *ClientImpl) SendMessageWithAttachments(teamID, channelID, parentID, me
 	return convertToMessage(res, teamID, channelID, ""), nil
 }
 
-func (tc *ClientImpl) SendChat(chatID, parentID, message string, mentions []models.ChatMessageMentionable) (*Message, error) {
+func (tc *ClientImpl) SendChat(chatID, parentID, message string, attachments []*Attachment, mentions []models.ChatMessageMentionable) (*Message, error) {
 	rmsg := models.NewChatMessage()
 
 	// TODO: Add support for parent id
 	_ = parentID
+
+	msteamsAttachments := []models.ChatMessageAttachmentable{}
+	for _, a := range attachments {
+		att := a
+		contentType := "reference"
+		attachment := models.NewChatMessageAttachment()
+		attachment.SetId(&att.ID)
+		attachment.SetContentType(&contentType)
+
+		extension := filepath.Ext(att.Name)
+		if !strings.HasSuffix(att.ContentURL, extension) {
+			teamsURL, err := url.Parse(att.ContentURL)
+			if err != nil {
+				tc.logError("Unable to parse URL", "Error", err.Error())
+				continue
+			}
+
+			q := teamsURL.Query()
+			fileQueryParam := q.Get("file")
+			q.Del("file")
+			teamsURL.RawQuery = q.Encode()
+
+			// We are deleting the file query param from the content URL as it is present in
+			// the middle and when MS Teams processes the content URL, it needs the file query param at the end
+			// otherwise, it gives the error: "contentUrl extension and name extension do not match"
+			// So, we are appending the file query param at the end
+			teamsURL.RawQuery += fmt.Sprintf("&file=%s", fileQueryParam)
+			att.ContentURL = teamsURL.String()
+		}
+
+		attachment.SetContentUrl(&att.ContentURL)
+		attachment.SetName(&att.Name)
+		msteamsAttachments = append(msteamsAttachments, attachment)
+		message = "<attachment id=\"" + att.ID + "\"></attachment>" + message
+	}
+
+	rmsg.SetAttachments(msteamsAttachments)
 
 	contentType := models.HTML_BODYTYPE
 
@@ -408,13 +445,34 @@ func (tc *ClientImpl) SendChat(chatID, parentID, message string, mentions []mode
 	return convertToMessage(res, "", "", chatID), nil
 }
 
-func (tc *ClientImpl) UploadFile(teamID, channelID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error) {
-	folderInfo, err := tc.client.TeamsById(teamID).ChannelsById(channelID).FilesFolder().Get(tc.ctx, nil)
-	if err != nil {
-		return nil, NormalizeGraphAPIError(err)
+func (tc *ClientImpl) UploadFile(teamID, channelID, chatID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error) {
+	driveID := ""
+	itemID := ""
+	if teamID != "" && channelID != "" {
+		folderInfo, err := tc.client.TeamsById(teamID).ChannelsById(channelID).FilesFolder().Get(tc.ctx, nil)
+		if err != nil {
+			return nil, NormalizeGraphAPIError(err)
+		}
+
+		driveID = *folderInfo.GetParentReference().GetDriveId()
+		itemID = *folderInfo.GetId() + ":/" + filename + ":"
+	} else {
+		drive, err := tc.client.Me().Drive().Get(tc.ctx, nil)
+		if err != nil {
+			return nil, NormalizeGraphAPIError(err)
+		}
+
+		driveID = *drive.GetId()
+		item, err := tc.client.DrivesById(driveID).Root().Get(tc.ctx, nil)
+		if err != nil {
+			return nil, NormalizeGraphAPIError(err)
+		}
+
+		itemID = *item.GetId() + ":/" + filename + ":"
 	}
 
-	uploadSession, err := tc.client.DrivesById(*folderInfo.GetParentReference().GetDriveId()).ItemsById(*folderInfo.GetId()+":/"+filename+":").CreateUploadSession().Post(tc.ctx, nil, nil)
+	fmt.Println("\n\n item id ", itemID)
+	uploadSession, err := tc.client.DrivesById(driveID).ItemsById(itemID).CreateUploadSession().Post(tc.ctx, nil, nil)
 	if err != nil {
 		return nil, NormalizeGraphAPIError(err)
 	}

--- a/server/msteams/interface.go
+++ b/server/msteams/interface.go
@@ -12,8 +12,8 @@ type Client interface {
 	CreateOrGetChatForUsers(usersIDs []string) (string, error)
 	SendMessage(teamID, channelID, parentID, message string) (*Message, error)
 	SendMessageWithAttachments(teamID, channelID, parentID, message string, attachments []*Attachment, mentions []models.ChatMessageMentionable) (*Message, error)
-	SendChat(chatID, parentID, message string, mentions []models.ChatMessageMentionable) (*Message, error)
-	UploadFile(teamID, channelID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error)
+	SendChat(chatID, parentID, message string, attachments []*Attachment, mentions []models.ChatMessageMentionable) (*Message, error)
+	UploadFile(teamID, channelID, chatID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error)
 	UpdateMessage(teamID, channelID, parentID, msgID, message string, mentions []models.ChatMessageMentionable) error
 	UpdateChatMessage(chatID, msgID, message string, mentions []models.ChatMessageMentionable) error
 	DeleteMessage(teamID, channelID, parentID, msgID string) error

--- a/server/msteams/interface.go
+++ b/server/msteams/interface.go
@@ -13,7 +13,7 @@ type Client interface {
 	SendMessage(teamID, channelID, parentID, message string) (*Message, error)
 	SendMessageWithAttachments(teamID, channelID, parentID, message string, attachments []*Attachment, mentions []models.ChatMessageMentionable) (*Message, error)
 	SendChat(chatID, parentID, message string, attachments []*Attachment, mentions []models.ChatMessageMentionable) (*Message, error)
-	UploadFile(teamID, channelID, chatID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error)
+	UploadFile(teamID, channelID, filename string, filesize int, mimeType string, data io.Reader) (*Attachment, error)
 	UpdateMessage(teamID, channelID, parentID, msgID, message string, mentions []models.ChatMessageMentionable) error
 	UpdateChatMessage(chatID, msgID, message string, mentions []models.ChatMessageMentionable) error
 	DeleteMessage(teamID, channelID, parentID, msgID string) error

--- a/server/msteams/mocks/Client.go
+++ b/server/msteams/mocks/Client.go
@@ -750,13 +750,13 @@ func (_m *Client) UpdateMessage(teamID string, channelID string, parentID string
 	return r0
 }
 
-// UploadFile provides a mock function with given fields: teamID, channelID, chatID, filename, filesize, mimeType, data
-func (_m *Client) UploadFile(teamID string, channelID string, chatID string, filename string, filesize int, mimeType string, data io.Reader) (*msteams.Attachment, error) {
-	ret := _m.Called(teamID, channelID, chatID, filename, filesize, mimeType, data)
+// UploadFile provides a mock function with given fields: teamID, channelID, filename, filesize, mimeType, data
+func (_m *Client) UploadFile(teamID string, channelID string, filename string, filesize int, mimeType string, data io.Reader) (*msteams.Attachment, error) {
+	ret := _m.Called(teamID, channelID, filename, filesize, mimeType, data)
 
 	var r0 *msteams.Attachment
-	if rf, ok := ret.Get(0).(func(string, string, string, string, int, string, io.Reader) *msteams.Attachment); ok {
-		r0 = rf(teamID, channelID, chatID, filename, filesize, mimeType, data)
+	if rf, ok := ret.Get(0).(func(string, string, string, int, string, io.Reader) *msteams.Attachment); ok {
+		r0 = rf(teamID, channelID, filename, filesize, mimeType, data)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*msteams.Attachment)
@@ -764,8 +764,8 @@ func (_m *Client) UploadFile(teamID string, channelID string, chatID string, fil
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, string, int, string, io.Reader) error); ok {
-		r1 = rf(teamID, channelID, chatID, filename, filesize, mimeType, data)
+	if rf, ok := ret.Get(1).(func(string, string, string, int, string, io.Reader) error); ok {
+		r1 = rf(teamID, channelID, filename, filesize, mimeType, data)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/msteams/mocks/Client.go
+++ b/server/msteams/mocks/Client.go
@@ -505,13 +505,13 @@ func (_m *Client) RefreshSubscription(subscriptionID string) (*time.Time, error)
 	return r0, r1
 }
 
-// SendChat provides a mock function with given fields: chatID, parentID, message, mentions
-func (_m *Client) SendChat(chatID string, parentID string, message string, mentions []models.ChatMessageMentionable) (*msteams.Message, error) {
-	ret := _m.Called(chatID, parentID, message, mentions)
+// SendChat provides a mock function with given fields: chatID, parentID, message, attachments, mentions
+func (_m *Client) SendChat(chatID string, parentID string, message string, attachments []*msteams.Attachment, mentions []models.ChatMessageMentionable) (*msteams.Message, error) {
+	ret := _m.Called(chatID, parentID, message, attachments, mentions)
 
 	var r0 *msteams.Message
-	if rf, ok := ret.Get(0).(func(string, string, string, []models.ChatMessageMentionable) *msteams.Message); ok {
-		r0 = rf(chatID, parentID, message, mentions)
+	if rf, ok := ret.Get(0).(func(string, string, string, []*msteams.Attachment, []models.ChatMessageMentionable) *msteams.Message); ok {
+		r0 = rf(chatID, parentID, message, attachments, mentions)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*msteams.Message)
@@ -519,8 +519,8 @@ func (_m *Client) SendChat(chatID string, parentID string, message string, menti
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, []models.ChatMessageMentionable) error); ok {
-		r1 = rf(chatID, parentID, message, mentions)
+	if rf, ok := ret.Get(1).(func(string, string, string, []*msteams.Attachment, []models.ChatMessageMentionable) error); ok {
+		r1 = rf(chatID, parentID, message, attachments, mentions)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -750,13 +750,13 @@ func (_m *Client) UpdateMessage(teamID string, channelID string, parentID string
 	return r0
 }
 
-// UploadFile provides a mock function with given fields: teamID, channelID, filename, filesize, mimeType, data
-func (_m *Client) UploadFile(teamID string, channelID string, filename string, filesize int, mimeType string, data io.Reader) (*msteams.Attachment, error) {
-	ret := _m.Called(teamID, channelID, filename, filesize, mimeType, data)
+// UploadFile provides a mock function with given fields: teamID, channelID, chatID, filename, filesize, mimeType, data
+func (_m *Client) UploadFile(teamID string, channelID string, chatID string, filename string, filesize int, mimeType string, data io.Reader) (*msteams.Attachment, error) {
+	ret := _m.Called(teamID, channelID, chatID, filename, filesize, mimeType, data)
 
 	var r0 *msteams.Attachment
-	if rf, ok := ret.Get(0).(func(string, string, string, int, string, io.Reader) *msteams.Attachment); ok {
-		r0 = rf(teamID, channelID, filename, filesize, mimeType, data)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, int, string, io.Reader) *msteams.Attachment); ok {
+		r0 = rf(teamID, channelID, chatID, filename, filesize, mimeType, data)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*msteams.Attachment)
@@ -764,8 +764,8 @@ func (_m *Client) UploadFile(teamID string, channelID string, filename string, f
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, int, string, io.Reader) error); ok {
-		r1 = rf(teamID, channelID, filename, filesize, mimeType, data)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, int, string, io.Reader) error); ok {
+		r1 = rf(teamID, channelID, chatID, filename, filesize, mimeType, data)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/testutils/data.go
+++ b/server/testutils/data.go
@@ -59,6 +59,10 @@ func GetID() string {
 	return "sfmq19kpztg5iy47ebe51hb31w"
 }
 
+func GetMSTeamsChannelID() string {
+	return "qplsnwere9nurernidteoqw"
+}
+
 func GetPost(channelID, userID string) *model.Post {
 	return &model.Post{
 		Id:        GetID(),
@@ -127,4 +131,25 @@ func GetChannelLinks(count int) []*storemodels.ChannelLink {
 	}
 
 	return links
+}
+
+func GetFileInfo() *model.FileInfo {
+	return &model.FileInfo{
+		Id:       GetID(),
+		Name:     "mockFileName",
+		Size:     1,
+		MimeType: "mockMimeType",
+	}
+}
+
+func GetPostFromTeamsMessage() *model.Post {
+	return &model.Post{
+		UserId:    GetUserID(),
+		ChannelId: GetChannelID(),
+		Message:   "mockText",
+		Props: model.StringInterface{
+			"msteams_sync_mock-BotUserID": true,
+		},
+		FileIds: model.StringArray{},
+	}
 }


### PR DESCRIPTION
#### Summary
Added support to send attachments in DMs and GMs from Teams to MM and MM to Teams.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/167
