### PR TITLE
[MI-3167] Fix TODO comment: Deduplicate calls to refresh subscription when a change request is received from Teams

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -86,12 +86,18 @@ func (a *API) processActivity(w http.ResponseWriter, req *http.Request) {
 
 	a.p.API.LogDebug("Change activity request", "activities", activities)
 	errors := ""
+	refreshedSubscriptions := make(map[string]bool)
 	for _, activity := range activities.Value {
 		if activity.ClientState != a.p.getConfiguration().WebhookSecret {
 			errors += "Invalid webhook secret"
 			continue
 		}
-		a.refreshSubscriptionIfNeeded(activity)
+
+		if !refreshedSubscriptions[activity.SubscriptionID] {
+			refreshedSubscriptions[activity.SubscriptionID] = true
+			a.refreshSubscriptionIfNeeded(activity)
+		}
+
 		err := a.p.activityHandler.Handle(activity)
 		if err != nil {
 			a.p.API.LogError("Unable to process created activity", "activity", activity, "error", err.Error())
@@ -106,7 +112,6 @@ func (a *API) processActivity(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// TODO: Deduplicate this calls in case multiple activities are sent after the subscription receives the notification
 func (a *API) refreshSubscriptionIfNeeded(activity msteams.Activity) {
 	if time.Until(activity.SubscriptionExpirationDateTime) < (5 * time.Minute) {
 		expiresOn, err := a.p.msteamsAppClient.RefreshSubscription(activity.SubscriptionID)


### PR DESCRIPTION
TODO comment link: https://github.com/Brightscout/mattermost-plugin-msteams-sync/blob/8fbc18bfd33e13678e1657551c49cb388df3bd75/server/api.go#L109
