### PR TITLE
[MI-3223] Fixed the issue of OAuth state not being used properly

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -386,15 +385,19 @@ func (p *Plugin) GetMSTeamsChannelDetailsForAllTeams(msTeamsTeamIDsVsChannelsQue
 }
 
 func (p *Plugin) executeConnectCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	state, _ := json.Marshal(map[string]string{})
-
-	codeVerifier := model.NewId()
-	appErr := p.API.KVSet("_code_verifier_"+args.UserId, []byte(codeVerifier))
-	if appErr != nil {
+	state := fmt.Sprintf("%s_%s", model.NewId(), args.UserId)
+	if err := p.store.StoreOAuth2State(state); err != nil {
+		p.API.LogError("Error in storing the OAuth state", "error", err.Error())
 		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please, try again.")
 	}
 
-	connectURL := msteams.GetAuthURL(p.GetURL()+"/oauth-redirect", p.configuration.TenantID, p.configuration.ClientID, p.configuration.ClientSecret, string(state), codeVerifier)
+	codeVerifier := model.NewId()
+	if appErr := p.API.KVSet("_code_verifier_"+args.UserId, []byte(codeVerifier)); appErr != nil {
+		p.API.LogError("Error in storing the code verifier", "error", appErr.Error())
+		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please, try again.")
+	}
+
+	connectURL := msteams.GetAuthURL(p.GetURL()+"/oauth-redirect", p.configuration.TenantID, p.configuration.ClientID, p.configuration.ClientSecret, state, codeVerifier)
 	p.sendBotEphemeralPost(args.UserId, args.ChannelId, fmt.Sprintf("Visit the URL for the auth dialog: %v", connectURL))
 	return &model.CommandResponse{}, nil
 }
@@ -404,7 +407,11 @@ func (p *Plugin) executeConnectBotCommand(args *model.CommandArgs) (*model.Comma
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to connect the bot account, only system admins can connect the bot account.")
 	}
 
-	state, _ := json.Marshal(map[string]string{"auth_type": "bot"})
+	state := fmt.Sprintf("%s_%s", model.NewId(), p.userID)
+	if err := p.store.StoreOAuth2State(state); err != nil {
+		p.API.LogError("Error in storing the OAuth state", "error", err.Error())
+		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please, try again.")
+	}
 
 	codeVerifier := model.NewId()
 	appErr := p.API.KVSet("_code_verifier_"+p.GetBotUserID(), []byte(codeVerifier))

--- a/server/command.go
+++ b/server/command.go
@@ -388,13 +388,13 @@ func (p *Plugin) executeConnectCommand(args *model.CommandArgs) (*model.CommandR
 	state := fmt.Sprintf("%s_%s", model.NewId(), args.UserId)
 	if err := p.store.StoreOAuth2State(state); err != nil {
 		p.API.LogError("Error in storing the OAuth state", "error", err.Error())
-		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please, try again.")
+		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please try again.")
 	}
 
 	codeVerifier := model.NewId()
 	if appErr := p.API.KVSet("_code_verifier_"+args.UserId, []byte(codeVerifier)); appErr != nil {
 		p.API.LogError("Error in storing the code verifier", "error", appErr.Error())
-		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please, try again.")
+		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please try again.")
 	}
 
 	connectURL := msteams.GetAuthURL(p.GetURL()+"/oauth-redirect", p.configuration.TenantID, p.configuration.ClientID, p.configuration.ClientSecret, state, codeVerifier)
@@ -410,16 +410,16 @@ func (p *Plugin) executeConnectBotCommand(args *model.CommandArgs) (*model.Comma
 	state := fmt.Sprintf("%s_%s", model.NewId(), p.userID)
 	if err := p.store.StoreOAuth2State(state); err != nil {
 		p.API.LogError("Error in storing the OAuth state", "error", err.Error())
-		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the account, please, try again.")
+		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the bot account, please try again.")
 	}
 
 	codeVerifier := model.NewId()
 	appErr := p.API.KVSet("_code_verifier_"+p.GetBotUserID(), []byte(codeVerifier))
 	if appErr != nil {
-		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the bot account, please, try again.")
+		return p.cmdError(args.UserId, args.ChannelId, "Error trying to connect the bot account, please try again.")
 	}
 
-	connectURL := msteams.GetAuthURL(p.GetURL()+"/oauth-redirect", p.configuration.TenantID, p.configuration.ClientID, p.configuration.ClientSecret, string(state), codeVerifier)
+	connectURL := msteams.GetAuthURL(p.GetURL()+"/oauth-redirect", p.configuration.TenantID, p.configuration.ClientID, p.configuration.ClientSecret, state, codeVerifier)
 
 	p.sendBotEphemeralPost(args.UserId, args.ChannelId, fmt.Sprintf("Visit the URL for the auth dialog: %v", connectURL))
 	return &model.CommandResponse{}, nil

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -662,6 +662,20 @@ func (_m *Store) StoreDMAndGMChannelPromptTime(channelID string, userID string, 
 	return r0
 }
 
+// StoreOAuth2State provides a mock function with given fields: state
+func (_m *Store) StoreOAuth2State(state string) error {
+	ret := _m.Called(state)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(state)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // TeamsToMattermostUserID provides a mock function with given fields: userID
 func (_m *Store) TeamsToMattermostUserID(userID string) (string, error) {
 	ret := _m.Called(userID)
@@ -690,6 +704,20 @@ func (_m *Store) UpdateSubscriptionExpiresOn(subscriptionID string, expiresOn ti
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, time.Time) error); ok {
 		r0 = rf(subscriptionID, expiresOn)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// VerifyOAuth2State provides a mock function with given fields: state
+func (_m *Store) VerifyOAuth2State(state string) error {
+	ret := _m.Called(state)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(state)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
#### Summary
- Created new store functions for storing and verifying OAuth state
- Added the logic of generating new state and storing it in the KV store with a timeout
- Added the logic of verifying the OAuth state when API call is redirected

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/193