### PR TITLE
Propose naming the plugin "MS Teams Connector"

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "com.mattermost.msteams-sync",
-    "name": "MSTeams Sync",
+    "name": "Mattermost for Microsoft Teams",
     "description": "Plugin to sync Mattermost channels with Microsoft Teams channels",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync",
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "com.mattermost.msteams-sync",
-    "name": "Mattermost for Microsoft Teams",
+    "name": "MS Teams Connector",
     "description": "Plugin to sync Mattermost channels with Microsoft Teams channels",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync",
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",


### PR DESCRIPTION
Given this plugin now supports two use cases -- a) synchronizing channels between the two platforms b) embedding Mattermost in Microsoft Teams -- and our marketing collateral refers to our solution as [Mattermost for Microsoft Teams](https://mattermost.com/solutions/mattermost-for-microsoft-teams/), propose using consistent naming for the integration as well.

We should also consider naming this repo as 'mattermost-for-microsoft-teams' for consistency.

Definitely open for feedback & if there are additional conversations we've held around naming this integration.

cc @johndavidlugtu @jespino @wiggin77 @azigler @mkdbns 