### PR TITLE
[MI-3327] Fixed the issue of replies and messages not being synced from Teams to MM for non-connected user

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ There are two methods by which you can connect your Mattermost account to your M
 - **Connecting the bot account**
     - Run the slash command `/msteams-sync connect-bot` in any channel.
     - This command is visible and accessible by system admins only.
-    - After running the slash command, you will get an ephemeral message from the MS Teams bot containing a link to connect your account.
-    - Click on that link. If it asks for login, enter your Microsoft credentials to connect your account.
-    - Refer [here](./docs/azure_setup.md#step-2-create-a-user-account-to-act-as-a-bot) for more details on connecting the bot account.
+    - After running the slash command, you will get an ephemeral message from the MS Teams bot containing a link to connect the bot account.
+    - Click on that link. If it asks for login, enter the Microsoft credentials for the dummy account created following [these steps](./docs/azure_setup.md#step-2-create-a-user-account-to-act-as-a-bot).
+    - Refer [here](./docs/azure_setup.md#step-2-create-a-user-account-to-act-as-a-bot) for more details.
 
 - **FAQs**
     - Read about the FAQs [here](./docs/faqs.md)

--- a/docs/azure_setup.md
+++ b/docs/azure_setup.md
@@ -73,6 +73,8 @@ Select **Register** to submit the form.
 
 ![image](https://user-images.githubusercontent.com/100013900/232403027-6d3ce866-d404-4ef2-a27b-ef5cc897cb25.png)
 
+**Note:** After you've connected the bot user to the dummy account on MS Teams, all the messages that are posted from the dummy account on MS Teams will not be synced back to Mattermost as we consider the dummy account a "bot" and messages from bots are ignored.
+
 ### Step 3: Ensure you have the metered APIs enabled (and the pay subscription associated to it)
 
 1. Follow the steps here: https://learn.microsoft.com/en-us/graph/metered-api-setup

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "0.3.8",
+    "version": "0.3.10",
     "min_server_version": "7.0.0",
     "server": {
         "executables": {

--- a/server/handlers/getters.go
+++ b/server/handlers/getters.go
@@ -32,14 +32,7 @@ func (ah *ActivityHandler) getMessageFromChat(chat *msteams.Chat, messageID stri
 }
 
 func (ah *ActivityHandler) getReplyFromChannel(userID string, teamID, channelID, messageID, replyID string) (*msteams.Message, error) {
-	client, err := ah.plugin.GetClientForUser(userID)
-	if err != nil {
-		ah.plugin.GetAPI().LogError("unable to get bot client", "error", err)
-		return nil, err
-	}
-
-	var msg *msteams.Message
-	msg, err = client.GetReply(teamID, channelID, messageID, replyID)
+	msg, err := ah.plugin.GetClientForApp().GetReply(teamID, channelID, messageID, replyID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to get original post", "error", err)
 		return nil, err
@@ -48,13 +41,7 @@ func (ah *ActivityHandler) getReplyFromChannel(userID string, teamID, channelID,
 }
 
 func (ah *ActivityHandler) getMessageFromChannel(userID string, teamID, channelID, messageID string) (*msteams.Message, error) {
-	client, err := ah.plugin.GetClientForUser(userID)
-	if err != nil {
-		ah.plugin.GetAPI().LogError("unable to get bot client", "error", err)
-		return nil, err
-	}
-
-	msg, err := client.GetMessage(teamID, channelID, messageID)
+	msg, err := ah.plugin.GetClientForApp().GetMessage(teamID, channelID, messageID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to get original post", "error", err)
 		return nil, err

--- a/server/handlers/getters.go
+++ b/server/handlers/getters.go
@@ -31,7 +31,7 @@ func (ah *ActivityHandler) getMessageFromChat(chat *msteams.Chat, messageID stri
 	return msg, nil
 }
 
-func (ah *ActivityHandler) getReplyFromChannel(userID string, teamID, channelID, messageID, replyID string) (*msteams.Message, error) {
+func (ah *ActivityHandler) getReplyFromChannel(teamID, channelID, messageID, replyID string) (*msteams.Message, error) {
 	msg, err := ah.plugin.GetClientForApp().GetReply(teamID, channelID, messageID, replyID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to get original post", "error", err)
@@ -40,7 +40,7 @@ func (ah *ActivityHandler) getReplyFromChannel(userID string, teamID, channelID,
 	return msg, nil
 }
 
-func (ah *ActivityHandler) getMessageFromChannel(userID string, teamID, channelID, messageID string) (*msteams.Message, error) {
+func (ah *ActivityHandler) getMessageFromChannel(teamID, channelID, messageID string) (*msteams.Message, error) {
 	msg, err := ah.plugin.GetClientForApp().GetMessage(teamID, channelID, messageID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to get original post", "error", err)
@@ -72,10 +72,8 @@ func (ah *ActivityHandler) getMessageAndChatFromActivityIds(activityIds msteams.
 		return msg, chat, nil
 	}
 
-	userID := ah.getUserIDForChannelLink(activityIds.TeamID, activityIds.ChannelID)
-
 	if activityIds.ReplyID != "" {
-		msg, err := ah.getReplyFromChannel(userID, activityIds.TeamID, activityIds.ChannelID, activityIds.MessageID, activityIds.ReplyID)
+		msg, err := ah.getReplyFromChannel(activityIds.TeamID, activityIds.ChannelID, activityIds.MessageID, activityIds.ReplyID)
 		if err != nil {
 			ah.plugin.GetAPI().LogError("Unable to get original post", "error", err)
 			return nil, nil, err
@@ -83,7 +81,7 @@ func (ah *ActivityHandler) getMessageAndChatFromActivityIds(activityIds msteams.
 		return msg, nil, nil
 	}
 
-	msg, err := ah.getMessageFromChannel(userID, activityIds.TeamID, activityIds.ChannelID, activityIds.MessageID)
+	msg, err := ah.getMessageFromChannel(activityIds.TeamID, activityIds.ChannelID, activityIds.MessageID)
 	if err != nil {
 		ah.plugin.GetAPI().LogError("Unable to get original post", "error", err)
 		return nil, nil, err

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -365,27 +365,17 @@ func TestGetMessageFromChannel(t *testing.T) {
 		setupClient   func()
 	}{
 		{
-			description: "Successfully got reply from channel",
+			description: "Successfully got message from channel",
 			userID:      testutils.GetUserID(),
 			teamID:      testutils.GetTeamUserID(),
 			channelID:   testutils.GetChannelID(),
 			messageID:   testutils.GetMessageID(),
 			setupPlugin: func(p *mocksPlugin.PluginIface) {
-				p.On("GetClientForUser", testutils.GetUserID()).Return(client, nil)
+				p.On("GetClientForApp").Return(client)
 			},
 			setupClient: func() {
 				client.On("GetMessage", testutils.GetTeamUserID(), testutils.GetChannelID(), testutils.GetMessageID()).Return(&msteams.Message{}, nil)
 			},
-		},
-		{
-			description: "Unable to get bot client",
-			userID:      "mock-userID",
-			setupPlugin: func(p *mocksPlugin.PluginIface) {
-				p.On("GetClientForUser", "mock-userID").Return(nil, errors.New("Error while getting bot client"))
-				p.On("GetAPI").Return(mockAPI)
-			},
-			setupClient:   func() {},
-			expectedError: "Error while getting bot client",
 		},
 		{
 			description: "Unable to get original post",
@@ -394,7 +384,7 @@ func TestGetMessageFromChannel(t *testing.T) {
 			channelID:   testutils.GetChannelID(),
 			messageID:   "mock-messageID",
 			setupPlugin: func(p *mocksPlugin.PluginIface) {
-				p.On("GetClientForUser", testutils.GetUserID()).Return(client, nil)
+				p.On("GetClientForApp").Return(client)
 				p.On("GetAPI").Return(mockAPI)
 			},
 			setupClient: func() {
@@ -445,21 +435,11 @@ func TestGetReplyFromChannel(t *testing.T) {
 			messageID:   testutils.GetMessageID(),
 			replyID:     testutils.GetReplyID(),
 			setupPlugin: func(p *mocksPlugin.PluginIface) {
-				p.On("GetClientForUser", testutils.GetUserID()).Return(client, nil)
+				p.On("GetClientForApp").Return(client)
 			},
 			setupClient: func() {
 				client.On("GetReply", testutils.GetTeamUserID(), testutils.GetChannelID(), testutils.GetMessageID(), testutils.GetReplyID()).Return(&msteams.Message{}, nil)
 			},
-		},
-		{
-			description: "Unable to get bot client",
-			userID:      "mock-userID",
-			setupPlugin: func(p *mocksPlugin.PluginIface) {
-				p.On("GetClientForUser", "mock-userID").Return(nil, errors.New("Error while getting bot client"))
-				p.On("GetAPI").Return(mockAPI)
-			},
-			setupClient:   func() {},
-			expectedError: "Error while getting bot client",
 		},
 		{
 			description: "Unable to get original post",
@@ -469,7 +449,7 @@ func TestGetReplyFromChannel(t *testing.T) {
 			messageID:   testutils.GetMessageID(),
 			replyID:     "mock-replyID",
 			setupPlugin: func(p *mocksPlugin.PluginIface) {
-				p.On("GetClientForUser", testutils.GetUserID()).Return(client, nil)
+				p.On("GetClientForApp").Return(client)
 				p.On("GetAPI").Return(mockAPI)
 			},
 			setupClient: func() {
@@ -628,7 +608,7 @@ func TestGetMessageAndChatFromActivityIds(t *testing.T) {
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface) {
 				p.On("GetStore").Return(store)
-				p.On("GetClientForUser", testutils.GetUserID()).Return(client, nil)
+				p.On("GetClientForApp").Return(client)
 				p.On("GetAPI").Return(mockAPI)
 			},
 			setupClient: func() {
@@ -648,7 +628,7 @@ func TestGetMessageAndChatFromActivityIds(t *testing.T) {
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface) {
 				p.On("GetStore").Return(store)
-				p.On("GetClientForUser", testutils.GetUserID()).Return(client, nil)
+				p.On("GetClientForApp").Return(client)
 				p.On("GetAPI").Return(mockAPI)
 			},
 			setupClient: func() {

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -441,8 +441,8 @@ func TestHandleCreatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
-				p.On("GetClientForApp").Return(client).Times(1)
-				p.On("GetAPI").Return(mockAPI).Times(4)
+				p.On("GetClientForApp").Return(client).Times(2)
+				p.On("GetAPI").Return(mockAPI).Times(5)
 				p.On("GetStore").Return(store).Times(6)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 			},
@@ -465,12 +465,12 @@ func TestHandleCreatedActivity(t *testing.T) {
 				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)
 			},
 			setupStore: func(store *mocksStore.Store) {
+				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamsUserID(), nil).Times(1)
+				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
 				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
 					Creator:             "mockCreator",
 					MattermostChannelID: testutils.GetChannelID(),
-				}, nil).Times(3)
-				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamsUserID(), nil).Times(1)
-				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
+				}, nil).Times(2)
 				store.On("GetPostInfoByMSTeamsID", testutils.GetChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
 				store.On("LinkPosts", storemodels.PostInfo{
 					MattermostID:   testutils.GetID(),
@@ -807,7 +807,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
 				p.On("GetClientForApp").Return(client).Times(1)
-				p.On("GetAPI").Return(mockAPI).Times(4)
+				p.On("GetAPI").Return(mockAPI).Times(5)
 				p.On("GetStore").Return(store).Times(5)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -456,7 +456,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
-				p.On("GetClientForUser", "mockCreator").Return(client, nil).Times(1)
+				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(4)
 				p.On("GetStore").Return(store).Times(7)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
@@ -822,7 +822,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
-				p.On("GetClientForUser", "mockCreator").Return(client, nil).Times(1)
+				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(4)
 				p.On("GetStore").Return(store).Times(6)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -458,7 +458,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
 				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(4)
-				p.On("GetStore").Return(store).Times(7)
+				p.On("GetStore").Return(store).Times(6)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 			},
 			setupClient: func(client *mocksClient.Client) {
@@ -482,9 +482,6 @@ func TestHandleCreatedActivity(t *testing.T) {
 				store.On("MattermostToTeamsUserID", "mock-BotUserID").Return(testutils.GetTeamUserID(), nil).Times(1)
 				store.On("TeamsToMattermostUserID", testutils.GetSenderID()).Return(testutils.GetUserID(), nil).Times(1)
 				store.On("GetPostInfoByMSTeamsID", testutils.GetChannelID(), testutils.GetMessageID()).Return(nil, nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mockCreator",
-				}, nil).Times(1)
 				store.On("LinkPosts", storemodels.PostInfo{
 					MattermostID:   testutils.GetID(),
 					MSTeamsID:      testutils.GetMessageID(),
@@ -824,7 +821,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store) {
 				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(4)
-				p.On("GetStore").Return(store).Times(6)
+				p.On("GetStore").Return(store).Times(5)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				mockAPI.On("KVSet", lastReceivedChangeKey, mock.Anything).Return(nil).Times(1)
 				p.On("GetBotUserID").Return(testutils.GetSenderID()).Times(2)
@@ -853,9 +850,6 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				store.On("GetPostInfoByMSTeamsID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&storemodels.PostInfo{
 					MSTeamsLastUpdateAt: time.Now(),
 					MattermostID:        "mockMattermostID",
-				}, nil).Times(1)
-				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
-					Creator: "mockCreator",
 				}, nil).Times(1)
 				store.On("GetLinkByMSTeamsChannelID", "mockTeamID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
 					Creator:             "mockCreator",


### PR DESCRIPTION
#### Summary
- Added the logic of using application level permissions for getting the message content inside a linked channel
- Modified the unit tests according to the change
- Modified the documentation for connecting the bot account a little bit

#### Ticket Link
Fixes #217 
