### PR TITLE
[MI-3333] Add console config to handle guest users and deactivated users on MS Teams

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -76,7 +76,6 @@
           "help_text": "Set the number of minutes between users sync (leave it empty to disable users sync)",
           "default": 0
         },{
-        },{
           "key": "syncGuestUsers",
           "display_name": "Sync guest users",
           "type": "bool",

--- a/plugin.json
+++ b/plugin.json
@@ -76,6 +76,13 @@
           "help_text": "Set the number of minutes between users sync (leave it empty to disable users sync)",
           "default": 0
         },{
+        },{
+          "key": "syncGuestUsers",
+          "display_name": "Sync guest users",
+          "type": "bool",
+          "help_text": "Set the value to 'true' to sync MS Teams guest users",
+          "default": false
+        },{
           "key": "syncDirectMessages",
           "display_name": "Sync direct and group messages",
           "type": "bool",

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "0.3.8",
+    "version": "0.3.10",
     "min_server_version": "7.0.0",
     "server": {
         "executables": {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,7 @@ type configuration struct {
 	EnabledTeams          string `json:"enabledteams"`
 	SyncDirectMessages    bool   `json:"syncdirectmessages"`
 	SyncUsers             int    `json:"syncusers"`
+	SyncGuestUsers        bool   `json:"syncGuestUsers"`
 	EnforceConnectedUsers bool   `json:"enforceconnectedusers"`
 	AllowSkipConnectUsers bool   `json:"allowskipconnectusers"`
 }

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -93,9 +93,11 @@ type Chat struct {
 }
 
 type User struct {
-	DisplayName string
-	ID          string
-	Mail        string
+	DisplayName      string
+	ID               string
+	Mail             string
+	Type             string
+	IsAccountEnabled bool
 }
 
 type ChatMember struct {
@@ -1337,7 +1339,7 @@ func (tc *ClientImpl) UnsetReaction(teamID, channelID, parentID, messageID, user
 
 func (tc *ClientImpl) ListUsers() ([]User, error) {
 	requestParameters := &users.UsersRequestBuilderGetQueryParameters{
-		Select: []string{"displayName", "id", "mail", "userPrincipalName"},
+		Select: []string{"displayName", "id", "mail", "userPrincipalName", "userType", "accountEnabled"},
 	}
 	configuration := &users.UsersRequestBuilderGetRequestConfiguration{
 		QueryParameters: requestParameters,
@@ -1360,8 +1362,10 @@ func (tc *ClientImpl) ListUsers() ([]User, error) {
 		}
 
 		user := User{
-			DisplayName: displayName,
-			ID:          *u.GetId(),
+			DisplayName:      displayName,
+			ID:               *u.GetId(),
+			Type:             *u.GetUserType(),
+			IsAccountEnabled: *u.GetAccountEnabled(),
 		}
 
 		if u.GetMail() != nil {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -444,26 +444,24 @@ func (p *Plugin) syncUsers() {
 		mmUser, isUserPresent := mmUsersMap[msUser.Mail]
 
 		if isUserPresent && isRemoteUser(mmUser) {
-			if !msUser.IsAccountEnabled {
-				// Deactivate the active Mattermost user corresponding to MS Teams user.
-				if mmUser.DeleteAt == 0 {
-					p.API.LogDebug("Deactivating the Mattermost user account", "Email", msUser.Mail)
-					if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
-						p.API.LogError("Unable to deactivate the Mattermost user account", "Email", mmUser.Email, "Error", err.Error())
-					}
-
-					continue
-				}
-			} else {
+			if msUser.IsAccountEnabled {
 				// Activate the deactived Mattermost user corresponding to MS Teams user.
 				if mmUser.DeleteAt != 0 {
 					p.API.LogDebug("Activating the inactive user", "Email", msUser.Mail)
 					if err := p.API.UpdateUserActive(mmUser.Id, true); err != nil {
 						p.API.LogError("Unable to activate the user", "Email", msUser.Mail, "Error", err.Error())
 					}
-
-					continue
 				}
+			} else {
+				// Deactivate the active Mattermost user corresponding to MS Teams user.
+				if mmUser.DeleteAt == 0 {
+					p.API.LogDebug("Deactivating the Mattermost user account", "Email", msUser.Mail)
+					if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
+						p.API.LogError("Unable to deactivate the Mattermost user account", "Email", mmUser.Email, "Error", err.Error())
+					}
+				}
+
+				continue
 			}
 		}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -468,14 +468,11 @@ func (p *Plugin) syncUsers() {
 		if msUser.Type == "Guest" {
 			// Check if syncing of MS Teams guest users is disabled.
 			if !syncGuestUsers {
-				if isUserPresent {
-					if isRemoteUser(mmUser) {
-						// Deactivate the Mattermost user corresponding to the MS Teams guest user.
-						p.API.LogDebug("Deactivating the guest user account", "Email", msUser.Mail)
-						if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
-							p.API.LogError("Unable to deactivate the guest user account", "Email", mmUser.Email, "Error", err.Error())
-							continue
-						}
+				if isUserPresent && isRemoteUser(mmUser) {
+					// Deactivate the Mattermost user corresponding to the MS Teams guest user.
+					p.API.LogDebug("Deactivating the guest user account", "Email", msUser.Mail)
+					if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
+						p.API.LogError("Unable to deactivate the guest user account", "Email", mmUser.Email, "Error", err.Error())
 					}
 				} else {
 					// Skip syncing of MS Teams guest user.

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -471,9 +471,9 @@ func (p *Plugin) syncUsers() {
 			// Check if syncing of MS Teams guest users is disabled.
 			if !syncGuestUsers {
 				if isUserPresent {
-					// Deactivate the Mattermost user corresponding to the MS Teams guest user.
-					p.API.LogDebug("Deactivating the guest user account", "Email", msUser.Mail)
 					if isRemoteUser(mmUser) {
+						// Deactivate the Mattermost user corresponding to the MS Teams guest user.
+						p.API.LogDebug("Deactivating the guest user account", "Email", msUser.Mail)
 						if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
 							p.API.LogError("Unable to deactivate the guest user account", "Email", mmUser.Email, "Error", err.Error())
 							continue


### PR DESCRIPTION
#### Summary

- Added logic to disable and enable syncing of guest users using console config.
- Added logic to deactivate synced users on Mattermost corresponding to MS Teams.

#### Ticket Link
Fixes #218 