### PR TITLE
[MI-3393] Fixed the issue of syncing guest users temporarily and ignoring messages

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "0.3.12",
+    "version": "0.3.13",
     "min_server_version": "7.0.0",
     "server": {
         "executables": {

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "0.3.8",
+    "version": "0.3.10",
     "min_server_version": "7.0.0",
     "server": {
         "executables": {

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -24,6 +24,7 @@ type pluginMock struct {
 	api                plugin.API
 	store              store.Store
 	syncDirectMessages bool
+	syncGuestUsers     bool
 	botUserID          string
 	url                string
 	appClient          msteams.Client
@@ -34,6 +35,7 @@ type pluginMock struct {
 func (pm *pluginMock) GetAPI() plugin.API                              { return pm.api }
 func (pm *pluginMock) GetStore() store.Store                           { return pm.store }
 func (pm *pluginMock) GetSyncDirectMessages() bool                     { return pm.syncDirectMessages }
+func (pm *pluginMock) GetSyncGuestUsers() bool                         { return pm.syncGuestUsers }
 func (pm *pluginMock) GetBotUserID() string                            { return pm.botUserID }
 func (pm *pluginMock) GetURL() string                                  { return pm.url }
 func (pm *pluginMock) GetClientForApp() msteams.Client                 { return pm.appClient }
@@ -55,6 +57,7 @@ func newTestHandler() *ActivityHandler {
 		botUserID:          "bot-user-id",
 		url:                "fake-url",
 		syncDirectMessages: false,
+		syncGuestUsers:     false,
 	})
 }
 
@@ -160,7 +163,7 @@ func TestGetOrCreateSyntheticUser(t *testing.T) {
 			test.SetupAPI(ah.plugin.GetAPI().(*plugintest.API))
 			test.SetupStore(ah.plugin.GetStore().(*storemocks.Store))
 			test.SetupAppClient(ah.plugin.GetClientForApp().(*mocksClient.Client))
-			result, err := ah.getOrCreateSyntheticUser(test.UserID, test.DisplayName)
+			result, err := ah.getOrCreateSyntheticUser(&msteams.User{ID: test.UserID}, false)
 			assert.Equal(test.ExpectedResult, result)
 			if test.ExpectedError {
 				assert.Error(err)

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -151,6 +151,20 @@ func (_m *PluginIface) GetSyncDirectMessages() bool {
 	return r0
 }
 
+// GetSyncGuestUsers provides a mock function with given fields:
+func (_m *PluginIface) GetSyncGuestUsers() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // GetURL provides a mock function with given fields:
 func (_m *PluginIface) GetURL() string {
 	ret := _m.Called()

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -1086,6 +1086,7 @@ func (tc *ClientImpl) GetUser(userID string) (*User, error) {
 		DisplayName: displayName,
 		ID:          *u.GetId(),
 		Mail:        strings.ToLower(email),
+		Type:        *u.GetUserType(),
 	}
 
 	return &user, nil

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -36,6 +36,7 @@ const (
 	pluginID              = "com.mattermost.msteams-sync"
 	clusterMutexKey       = "subscriptions_cluster_mutex"
 	lastReceivedChangeKey = "last_received_change"
+	msteamsUserTypeGuest  = "Guest"
 )
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
@@ -81,6 +82,10 @@ func (p *Plugin) GetStore() store.Store {
 
 func (p *Plugin) GetSyncDirectMessages() bool {
 	return p.getConfiguration().SyncDirectMessages
+}
+
+func (p *Plugin) GetSyncGuestUsers() bool {
+	return p.getConfiguration().SyncGuestUsers
 }
 
 func (p *Plugin) GetBotUserID() string {
@@ -465,7 +470,7 @@ func (p *Plugin) syncUsers() {
 			}
 		}
 
-		if msUser.Type == "Guest" {
+		if msUser.Type == msteamsUserTypeGuest {
 			// Check if syncing of MS Teams guest users is disabled.
 			if !syncGuestUsers {
 				if isUserPresent && isRemoteUser(mmUser) {
@@ -518,8 +523,17 @@ func (p *Plugin) syncUsers() {
 				continue
 			}
 
-			err = p.store.SetUserInfo(newUser.Id, msUser.ID, nil)
-			if err != nil {
+			preferences := model.Preferences{model.Preference{
+				UserId:   newUser.Id,
+				Category: model.PreferenceCategoryNotifications,
+				Name:     model.PreferenceNameEmailInterval,
+				Value:    "0",
+			}}
+			if prefErr := p.API.UpdatePreferencesForUser(newUser.Id, preferences); prefErr != nil {
+				p.API.LogError("Unable to disable email notifications for new user", "UserID", newUser.Id, "error", prefErr.Error())
+			}
+
+			if err = p.store.SetUserInfo(newUser.Id, msUser.ID, nil); err != nil {
 				p.API.LogError("Unable to set user info during sync user job", "email", msUser.Mail, "error", err.Error())
 			}
 		} else if (username != mmUser.Username || msUser.DisplayName != mmUser.FirstName) && mmUser.RemoteId != nil {


### PR DESCRIPTION
#### Summary
- Updated plugin version
- Added the logic to ignore messages from guest users for all channels/chats
- Added the logic to skip guest users from GMs when creating new GMs
- Added the logic to deactivate already existing synthetic users in MM who are guest users in Teams
- Added the logic to disable email notifications for synthetic users

#### Ticket Link
Fixes #236 