### PR TITLE
[MI-3395] Fixed the issue of email notifications being sent for synthetic users

### DIFF
--- a/server/handlers/getters.go
+++ b/server/handlers/getters.go
@@ -130,6 +130,8 @@ func (ah *ActivityHandler) getOrCreateSyntheticUser(user *msteams.User, createSy
 			Password:  ah.plugin.GenerateRandomPassword(),
 			RemoteId:  &shortUserID,
 		}
+		newMMUser.SetDefaultNotifications()
+		newMMUser.NotifyProps[model.EmailNotifyProp] = "false"
 
 		userSuffixID := 1
 		for {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -501,6 +501,8 @@ func (p *Plugin) syncUsers() {
 				FirstName: msUser.DisplayName,
 				Username:  username,
 			}
+			newMMUser.SetDefaultNotifications()
+			newMMUser.NotifyProps[model.EmailNotifyProp] = "false"
 
 			var newUser *model.User
 			for {


### PR DESCRIPTION
#### Summary
Added the logic of setting notify_props of the user when he's being created