### PR TITLE
[MI-3418] Fixed the issue of embedded images not working from Teams to MM

### DIFF
--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -3,16 +3,56 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"mime"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams"
 	"github.com/mattermost/mattermost-server/v6/app/imaging"
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
+func GetResourceIdsFromURL(weburl string) (*msteams.ActivityIds, error) {
+	parsedURL, err := url.Parse(weburl)
+	if err != nil {
+		return nil, err
+	}
+
+	path := strings.TrimPrefix(parsedURL.Path, "/beta/")
+	urlParts := strings.Split(path, "/")
+	activityIDs := &msteams.ActivityIds{}
+	if urlParts[0] == "chats" {
+		activityIDs.ChatID = urlParts[1]
+		activityIDs.MessageID = urlParts[3]
+		activityIDs.HostedContentsID = urlParts[5]
+	} else {
+		activityIDs.TeamID = urlParts[1]
+		activityIDs.ChannelID = urlParts[3]
+		activityIDs.MessageID = urlParts[5]
+		if strings.Contains(path, "replies") {
+			activityIDs.ReplyID = urlParts[7]
+			activityIDs.HostedContentsID = urlParts[9]
+		} else {
+			activityIDs.HostedContentsID = urlParts[7]
+		}
+	}
+
+	return activityIDs, nil
+}
+
 // handleDownloadFile handles file download
 func (ah *ActivityHandler) handleDownloadFile(weburl string, client msteams.Client) ([]byte, error) {
+	if strings.Contains(weburl, "hostedContents") && strings.HasSuffix(weburl, "$value") {
+		activityIDs, err := GetResourceIdsFromURL(weburl)
+		if err != nil {
+			return nil, err
+		}
+
+		return client.GetHostedFileContent(activityIDs)
+	}
+
 	data, err := client.GetFileContent(weburl)
 	if err != nil {
 		return nil, err
@@ -87,6 +127,17 @@ func (ah *ActivityHandler) handleAttachments(_, channelID string, text string, m
 				ah.plugin.GetAPI().LogError("image resolution is too high")
 				continue
 			}
+		}
+
+		if a.Name == "" {
+			extension := ""
+			extensions, extensionErr := mime.ExtensionsByType(contentType)
+			if extensionErr != nil {
+				ah.plugin.GetAPI().LogDebug("Unable to get the extensions using content type", "error", extensionErr.Error())
+			} else if len(extensions) > 0 {
+				extension = extensions[0]
+			}
+			a.Name = "Image Pasted at " + time.Now().Format("2023-01-02 15:03:05") + extension
 		}
 
 		fileInfo, appErr := ah.plugin.GetAPI().UploadFile(attachmentData, channelID, a.Name)

--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"mime"
 	"net/http"
 	"net/url"
@@ -136,7 +137,7 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 			} else if len(extensions) > 0 {
 				extension = extensions[0]
 			}
-			a.Name = "Image Pasted at " + time.Now().Format("2023-01-02 15:03:05") + extension
+			a.Name = fmt.Sprintf("Image Pasted at %s%s", time.Now().Format("2023-01-02 15:03:05"), extension)
 		}
 
 		fileInfo, appErr := ah.plugin.GetAPI().UploadFile(attachmentData, channelID, a.Name)

--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -14,24 +14,25 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-func GetResourceIdsFromURL(weburl string) (*msteams.ActivityIds, error) {
+func GetResourceIDsFromURL(weburl string) (*msteams.ActivityIds, error) {
 	parsedURL, err := url.Parse(weburl)
 	if err != nil {
 		return nil, err
 	}
 
 	path := strings.TrimPrefix(parsedURL.Path, "/beta/")
+	path = strings.TrimPrefix(path, "/v1.0/")
 	urlParts := strings.Split(path, "/")
 	activityIDs := &msteams.ActivityIds{}
-	if urlParts[0] == "chats" {
+	if urlParts[0] == "chats" && len(urlParts) >= 6 {
 		activityIDs.ChatID = urlParts[1]
 		activityIDs.MessageID = urlParts[3]
 		activityIDs.HostedContentsID = urlParts[5]
-	} else {
+	} else if len(urlParts) >= 6 {
 		activityIDs.TeamID = urlParts[1]
 		activityIDs.ChannelID = urlParts[3]
 		activityIDs.MessageID = urlParts[5]
-		if strings.Contains(path, "replies") {
+		if strings.Contains(path, "replies") && len(urlParts) >= 10 {
 			activityIDs.ReplyID = urlParts[7]
 			activityIDs.HostedContentsID = urlParts[9]
 		} else {
@@ -45,7 +46,7 @@ func GetResourceIdsFromURL(weburl string) (*msteams.ActivityIds, error) {
 // handleDownloadFile handles file download
 func (ah *ActivityHandler) handleDownloadFile(weburl string, client msteams.Client) ([]byte, error) {
 	if strings.Contains(weburl, "hostedContents") && strings.HasSuffix(weburl, "$value") {
-		activityIDs, err := GetResourceIdsFromURL(weburl)
+		activityIDs, err := GetResourceIDsFromURL(weburl)
 		if err != nil {
 			return nil, err
 		}

--- a/server/handlers/attachments_test.go
+++ b/server/handlers/attachments_test.go
@@ -26,11 +26,10 @@ func TestHandleDownloadFile(t *testing.T) {
 		userID        string
 		weburl        string
 		expectedError string
-		mockChat      *msteams.Chat
 		setupClient   func()
 	}{
 		{
-			description: "Successfully file downloaded for channel",
+			description: "Successfully file downloaded",
 			userID:      testutils.GetUserID(),
 			weburl:      "https://example.com/file1.txt",
 			setupClient: func() {
@@ -38,16 +37,11 @@ func TestHandleDownloadFile(t *testing.T) {
 			},
 		},
 		{
-			description: "Successfully file downloaded for chat",
+			description: "Successfully downloaded hosted content file",
 			userID:      testutils.GetUserID(),
-			weburl:      "https://example.com/file1.txt",
-			mockChat: &msteams.Chat{
-				Members: []msteams.ChatMember{
-					{UserID: testutils.GetTeamsUserID()},
-				},
-			},
+			weburl:      "https://graph.microsoft.com/beta/teams/mock-teamID/channels/mock-channelID/messages/mock-messageID/hostedContents/mock-hostedContentsID/$value",
 			setupClient: func() {
-				client.On("GetFileContent", "https://example.com/file1.txt").Return([]byte("data"), nil)
+				client.On("GetHostedFileContent", mock.AnythingOfType("*msteams.ActivityIds")).Return([]byte("data"), nil)
 			},
 		},
 		{
@@ -380,7 +374,7 @@ func TestHandleAttachments(t *testing.T) {
 						MaxFileSize: model.NewInt64(5),
 					},
 				})
-				mockAPI.On("UploadFile", []byte{}, testutils.GetChannelID(), "").Return(&model.FileInfo{}, nil)
+				mockAPI.On("UploadFile", []byte{}, testutils.GetChannelID(), mock.AnythingOfType("string")).Return(&model.FileInfo{}, nil)
 				mockAPI.On("LogDebug", "discarding the rest of the attachments as Mattermost supports only 10 attachments per post").Return()
 			},
 			setupClient: func(client *mocksClient.Client) {

--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -154,6 +154,7 @@ func getImageTagsFromHTML(text string) []string {
 				for _, a := range t.Attr {
 					if a.Key == "src" {
 						images = append(images, a.Val)
+						break
 					}
 				}
 			}

--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -33,6 +33,9 @@ func (ah *ActivityHandler) GetAvatarURL(userID string) string {
 func (ah *ActivityHandler) msgToPost(userID, channelID, senderID string, msg *msteams.Message, chat *msteams.Chat) (*model.Post, error) {
 	text := ah.handleMentions(msg)
 	text = ah.handleEmojis(text)
+	var embeddedImages []msteams.Attachment
+	text, embeddedImages = ah.handleImages(text)
+	msg.Attachments = append(msg.Attachments, embeddedImages...)
 	text = markdown.ConvertToMD(text)
 	props := make(map[string]interface{})
 	rootID := ""
@@ -123,4 +126,37 @@ func (ah *ActivityHandler) handleEmojis(text string) string {
 	}
 
 	return text
+}
+
+func (ah *ActivityHandler) handleImages(text string) (string, []msteams.Attachment) {
+	imageURLs := getImageTagsFromHTML(text)
+	var attachments []msteams.Attachment
+	for _, imageURL := range imageURLs {
+		attachments = append(attachments, msteams.Attachment{
+			ContentURL: imageURL,
+		})
+	}
+
+	text = imageRE.ReplaceAllString(text, "")
+	return text, attachments
+}
+
+func getImageTagsFromHTML(text string) []string {
+	tokenizer := html.NewTokenizer(strings.NewReader(text))
+	var images []string
+	for {
+		token := tokenizer.Next()
+		switch {
+		case token == html.ErrorToken:
+			return images
+		case token == html.StartTagToken:
+			if t := tokenizer.Token(); t.Data == "img" {
+				for _, a := range t.Attr {
+					if a.Key == "src" {
+						images = append(images, a.Val)
+					}
+				}
+			}
+		}
+	}
 }

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -18,6 +18,7 @@ import (
 var emojisReverseMap map[string]string
 
 var attachRE = regexp.MustCompile(`<attachment id=.*?attachment>`)
+var imageRE = regexp.MustCompile(`<img .*?>`)
 
 const (
 	lastReceivedChangeKey = "last_received_change"

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -159,11 +159,12 @@ type Activity struct {
 }
 
 type ActivityIds struct {
-	ChatID    string
-	TeamID    string
-	ChannelID string
-	MessageID string
-	ReplyID   string
+	ChatID           string
+	TeamID           string
+	ChannelID        string
+	MessageID        string
+	ReplyID          string
+	HostedContentsID string
 }
 
 type AccessToken struct {
@@ -1153,6 +1154,23 @@ func (tc *ClientImpl) GetFileContent(weburl string) ([]byte, error) {
 		return nil, NormalizeGraphAPIError(err)
 	}
 	return data, nil
+}
+
+func (tc *ClientImpl) GetHostedFileContent(activityIDs *ActivityIds) (contentData []byte, err error) {
+	if activityIDs.ChatID != "" {
+		contentData, err = tc.client.ChatsById(activityIDs.ChatID).MessagesById(activityIDs.MessageID).HostedContentsById(activityIDs.HostedContentsID).Content().Get(tc.ctx, nil)
+	} else {
+		if activityIDs.ReplyID != "" {
+			contentData, err = tc.client.TeamsById(activityIDs.TeamID).ChannelsById(activityIDs.ChannelID).MessagesById(activityIDs.MessageID).RepliesById(activityIDs.ReplyID).HostedContentsById(activityIDs.HostedContentsID).Content().Get(tc.ctx, nil)
+		} else {
+			contentData, err = tc.client.TeamsById(activityIDs.TeamID).ChannelsById(activityIDs.ChannelID).MessagesById(activityIDs.MessageID).HostedContentsById(activityIDs.HostedContentsID).Content().Get(tc.ctx, nil)
+		}
+	}
+	if err != nil {
+		return nil, NormalizeGraphAPIError(err)
+	}
+
+	return
 }
 
 func (tc *ClientImpl) GetCodeSnippet(url string) (string, error) {

--- a/server/msteams/interface.go
+++ b/server/msteams/interface.go
@@ -41,6 +41,7 @@ type Client interface {
 	GetMyID() (string, error)
 	GetMe() (*User, error)
 	GetFileContent(weburl string) ([]byte, error)
+	GetHostedFileContent(activityIDs *ActivityIds) ([]byte, error)
 	GetCodeSnippet(url string) (string, error)
 	ListUsers() ([]User, error)
 	ListTeams() ([]Team, error)

--- a/server/msteams/mocks/Client.go
+++ b/server/msteams/mocks/Client.go
@@ -231,6 +231,29 @@ func (_m *Client) GetFileContent(weburl string) ([]byte, error) {
 	return r0, r1
 }
 
+// GetHostedFileContent provides a mock function with given fields: activityIDs
+func (_m *Client) GetHostedFileContent(activityIDs *msteams.ActivityIds) ([]byte, error) {
+	ret := _m.Called(activityIDs)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(*msteams.ActivityIds) []byte); ok {
+		r0 = rf(activityIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*msteams.ActivityIds) error); ok {
+		r1 = rf(activityIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMe provides a mock function with given fields:
 func (_m *Client) GetMe() (*msteams.User, error) {
 	ret := _m.Called()


### PR DESCRIPTION
#### Summary
- Created a new client function to get hosted content file
- Added the logic to extract image URLs from the message by parsing HTML
- Added the logic to remove the image tags from the message
- Added the logic to download image from MS Teams and upload them on Mattermost with a new name
- Added a new field HostedContentID in the struct ActivityIDs
- Generated new mocks for the Client interface

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-msteams-sync/issues/247
