### PR TITLE
Bump plugin version to 1.0.2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "min_server_version": "7.0.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Bump plugin version to 1.0.2
 
#### Release notes
Supported Mattermost Server Versions: **7.0.0+**

## Enhancements
- 0bfbc895f2a70cba2ddec9137aa1def77937ab8f Added a new config setting for the prompt interval for DMs and GMs (#255 )

## Fixes
- 367aa038d68adc18c2d04fbf227948248fd67ebb Fixed the issue of attachments not opening in DMs/GMs for receivers due to permission issues. (#254 )
