### PR TITLE
[MI-3439] Added the logic to send an ephemeral post if an image is not delivered due to size/resolution limits

### DIFF
--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -80,10 +80,10 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 		}
 	}
 
-	errorsFound := false
+	errorFound := false
 	if client == nil {
 		ah.plugin.GetAPI().LogError("Unable to get the client")
-		return "", nil, "", errorsFound
+		return "", nil, "", errorFound
 	}
 
 	for _, a := range msg.Attachments {
@@ -112,7 +112,7 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 		fileSizeAllowed := *ah.plugin.GetAPI().GetConfig().FileSettings.MaxFileSize
 		if len(attachmentData) > int(fileSizeAllowed) {
 			ah.plugin.GetAPI().LogError("cannot upload file to Mattermost as its size is greater than allowed size", "filename", a.Name)
-			errorsFound = true
+			errorFound = true
 			continue
 		}
 
@@ -127,7 +127,7 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 			imageRes := int64(w) * int64(h)
 			if imageRes > *ah.plugin.GetAPI().GetConfig().FileSettings.MaxImageResolution {
 				ah.plugin.GetAPI().LogError("image resolution is too high")
-				errorsFound = true
+				errorFound = true
 				continue
 			}
 		}
@@ -157,7 +157,7 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 		}
 	}
 
-	return newText, attachments, parentID, errorsFound
+	return newText, attachments, parentID, errorFound
 }
 
 func (ah *ActivityHandler) handleCodeSnippet(client msteams.Client, attach msteams.Attachment, text string) string {

--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -63,7 +63,7 @@ func (ah *ActivityHandler) handleDownloadFile(weburl string, client msteams.Clie
 	return data, nil
 }
 
-func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteams.Message, chat *msteams.Chat) (string, model.StringArray, string) {
+func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteams.Message, chat *msteams.Chat) (string, model.StringArray, string, bool) {
 	attachments := []string{}
 	newText := text
 	parentID := ""
@@ -80,9 +80,10 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 		}
 	}
 
+	errorsFound := false
 	if client == nil {
 		ah.plugin.GetAPI().LogError("Unable to get the client")
-		return "", nil, ""
+		return "", nil, "", errorsFound
 	}
 
 	for _, a := range msg.Attachments {
@@ -111,6 +112,7 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 		fileSizeAllowed := *ah.plugin.GetAPI().GetConfig().FileSettings.MaxFileSize
 		if len(attachmentData) > int(fileSizeAllowed) {
 			ah.plugin.GetAPI().LogError("cannot upload file to Mattermost as its size is greater than allowed size", "filename", a.Name)
+			errorsFound = true
 			continue
 		}
 
@@ -125,6 +127,7 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 			imageRes := int64(w) * int64(h)
 			if imageRes > *ah.plugin.GetAPI().GetConfig().FileSettings.MaxImageResolution {
 				ah.plugin.GetAPI().LogError("image resolution is too high")
+				errorsFound = true
 				continue
 			}
 		}
@@ -153,7 +156,8 @@ func (ah *ActivityHandler) handleAttachments(channelID, text string, msg *msteam
 			break
 		}
 	}
-	return newText, attachments, parentID
+
+	return newText, attachments, parentID, errorsFound
 }
 
 func (ah *ActivityHandler) handleCodeSnippet(client msteams.Client, attach msteams.Attachment, text string) string {

--- a/server/handlers/attachments_test.go
+++ b/server/handlers/attachments_test.go
@@ -269,6 +269,7 @@ func TestHandleAttachments(t *testing.T) {
 		expectedText               string
 		expectedAttachmentIDsCount int
 		expectedParentID           string
+		expectedError              bool
 	}{
 		{
 			description: "Successfully handled attachments",
@@ -335,7 +336,8 @@ func TestHandleAttachments(t *testing.T) {
 					Name: "mock-name",
 				},
 			},
-			expectedText: "mock-text",
+			expectedText:  "mock-text",
+			expectedError: true,
 		},
 		{
 			description: "Error uploading the file",
@@ -463,10 +465,11 @@ func TestHandleAttachments(t *testing.T) {
 				ChannelID:   testutils.GetChannelID(),
 			}
 
-			newText, attachmentIDs, parentID := ah.handleAttachments(testutils.GetChannelID(), "mock-text", attachments, nil)
+			newText, attachmentIDs, parentID, errorsFound := ah.handleAttachments(testutils.GetChannelID(), "mock-text", attachments, nil)
 			assert.Equal(t, testCase.expectedParentID, parentID)
 			assert.Equal(t, testCase.expectedAttachmentIDsCount, len(attachmentIDs))
 			assert.Equal(t, testCase.expectedText, newText)
+			assert.Equal(t, testCase.expectedError, errorsFound)
 		})
 	}
 }

--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -47,7 +47,7 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Me
 		}
 	}
 
-	newText, attachments, parentID, errorsFound := ah.handleAttachments(channelID, text, msg, chat)
+	newText, attachments, parentID, errorFound := ah.handleAttachments(channelID, text, msg, chat)
 	text = newText
 	if parentID != "" {
 		rootID = parentID
@@ -65,7 +65,7 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Me
 		post.AddProp("from_webhook", "true")
 		post.AddProp("override_icon_url", ah.GetAvatarURL(msg.UserID))
 	}
-	return post, errorsFound
+	return post, errorFound
 }
 
 func (ah *ActivityHandler) handleMentions(msg *msteams.Message) string {

--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -30,7 +30,7 @@ func (ah *ActivityHandler) GetAvatarURL(userID string) string {
 	return defaultAvatarURL
 }
 
-func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Message, chat *msteams.Chat) (*model.Post, error) {
+func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Message, chat *msteams.Chat) (*model.Post, bool) {
 	text := ah.handleMentions(msg)
 	text = ah.handleEmojis(text)
 	var embeddedImages []msteams.Attachment
@@ -47,7 +47,7 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Me
 		}
 	}
 
-	newText, attachments, parentID := ah.handleAttachments(channelID, text, msg, chat)
+	newText, attachments, parentID, errorsFound := ah.handleAttachments(channelID, text, msg, chat)
 	text = newText
 	if parentID != "" {
 		rootID = parentID
@@ -65,7 +65,7 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Me
 		post.AddProp("from_webhook", "true")
 		post.AddProp("override_icon_url", ah.GetAvatarURL(msg.UserID))
 	}
-	return post, nil
+	return post, errorsFound
 }
 
 func (ah *ActivityHandler) handleMentions(msg *msteams.Message) string {

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -294,7 +294,7 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 		_ = ah.plugin.GetAPI().SendEphemeralPost(senderID, &model.Post{
 			ChannelId: channelID,
 			UserId:    ah.plugin.GetBotUserID(),
-			Message:   "Some images were not delivered due to size/resolution limits.",
+			Message:   "Some images could not be delivered because they exceeded the maximum resolution and/or size allowed.",
 		})
 	}
 

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -271,7 +271,7 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 		return
 	}
 
-	post, errorsFound := ah.msgToPost(channelID, senderID, msg, chat)
+	post, errorFound := ah.msgToPost(channelID, senderID, msg, chat)
 	ah.plugin.GetAPI().LogDebug("Post generated", "post", post)
 
 	// Avoid possible duplication
@@ -290,7 +290,7 @@ func (ah *ActivityHandler) handleCreatedActivity(activityIds msteams.ActivityIds
 	}
 
 	ah.plugin.GetAPI().LogDebug("Post created", "post", newPost)
-	if errorsFound {
+	if errorFound {
 		_ = ah.plugin.GetAPI().SendEphemeralPost(senderID, &model.Post{
 			ChannelId: channelID,
 			UserId:    ah.plugin.GetBotUserID(),


### PR DESCRIPTION
#### Summary
- Added the logic to send an ephemeral post from the MS Teams bot if attachment is not delivered due to high size/resolution
- Modified the return type of functions handleAttachments and msgToPost
- Fixed the failing unit tests

#### Ticket Link
Fixes #249 
