### PR TITLE
[MI-3446] Fixed the issue of GIFs not sending using the Gif button in Teams to MM

### DIFF
--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -46,7 +46,7 @@ func GetResourceIDsFromURL(weburl string) (*msteams.ActivityIds, error) {
 
 // handleDownloadFile handles file download
 func (ah *ActivityHandler) handleDownloadFile(weburl string, client msteams.Client) ([]byte, error) {
-	if strings.Contains(weburl, "hostedContents") && strings.HasSuffix(weburl, "$value") {
+	if strings.Contains(weburl, hostedContentsStr) && strings.HasSuffix(weburl, "$value") {
 		activityIDs, err := GetResourceIDsFromURL(weburl)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
#### Summary
- Added the logic to replace only those images which contain hosted contents with empty string in the HTML
- Added the logic to treat only those images as attachments which contain hosted contents

#### Ticket Link
Fixes #264 
