### PR TITLE
[MI-3462] Modified the subscription handling when receiving change notifications

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams"
 	clientmocks "github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams/mocks"
 	storemocks "github.com/mattermost/mattermost-plugin-msteams-sync/server/store/mocks"
+	"github.com/mattermost/mattermost-plugin-msteams-sync/server/store/storemodels"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/testutils"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
@@ -407,7 +408,11 @@ func TestProcessLifecycle(t *testing.T) {
 			SetupAPI:    func(api *plugintest.API) {},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {},
 			SetupStore: func(store *storemocks.Store) {
-				store.On("GetSubscriptionType", "mockID").Return("allChats", nil)
+				store.On("GetChannelSubscription", "mockID").Return(&storemodels.ChannelSubscription{
+					TeamID:    testutils.GetTeamsTeamID(),
+					ChannelID: testutils.GetMSTeamsChannelID(),
+				}, nil).Once()
+				store.On("GetLinkByMSTeamsChannelID", testutils.GetTeamsTeamID(), testutils.GetMSTeamsChannelID()).Return(nil, nil).Once()
 			},
 			RequestBody: `{
 				"Value": [{
@@ -426,7 +431,11 @@ func TestProcessLifecycle(t *testing.T) {
 				client.On("RefreshSubscription", "mockID").Return(&newTime, nil)
 			},
 			SetupStore: func(store *storemocks.Store) {
-				store.On("GetSubscriptionType", "mockID").Return("allChats", nil)
+				store.On("GetChannelSubscription", "mockID").Return(&storemodels.ChannelSubscription{
+					TeamID:    testutils.GetTeamsTeamID(),
+					ChannelID: testutils.GetMSTeamsChannelID(),
+				}, nil).Once()
+				store.On("GetLinkByMSTeamsChannelID", testutils.GetTeamsTeamID(), testutils.GetMSTeamsChannelID()).Return(nil, nil).Once()
 				store.On("UpdateSubscriptionExpiresOn", "mockID", newTime).Return(nil)
 			},
 			RequestBody: `{

--- a/server/command.go
+++ b/server/command.go
@@ -253,13 +253,13 @@ func (p *Plugin) executeUnlinkCommand(args *model.CommandArgs) (*model.CommandRe
 		return &model.CommandResponse{}, nil
 	}
 
-	if err = p.msteamsAppClient.DeleteSubscription(subscription.SubscriptionID); err != nil {
-		p.API.LogDebug("Unable to delete the subscription on MS Teams", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
+	if err = p.store.DeleteSubscription(subscription.SubscriptionID); err != nil {
+		p.API.LogDebug("Unable to delete the subscription from the DB", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
 		return &model.CommandResponse{}, nil
 	}
 
-	if err = p.store.DeleteSubscription(subscription.SubscriptionID); err != nil {
-		p.API.LogDebug("Unable to delete the subscription from the DB", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
+	if err = p.msteamsAppClient.DeleteSubscription(subscription.SubscriptionID); err != nil {
+		p.API.LogDebug("Unable to delete the subscription on MS Teams", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
 	}
 
 	return &model.CommandResponse{}, nil

--- a/server/command.go
+++ b/server/command.go
@@ -241,6 +241,7 @@ func (p *Plugin) executeUnlinkCommand(args *model.CommandArgs) (*model.CommandRe
 	}
 
 	if err = p.store.DeleteLinkByChannelID(channel.Id); err != nil {
+		p.API.LogDebug("Unable to delete the link by channel ID", "error", err.Error())
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to delete link.")
 	}
 
@@ -252,13 +253,13 @@ func (p *Plugin) executeUnlinkCommand(args *model.CommandArgs) (*model.CommandRe
 		return &model.CommandResponse{}, nil
 	}
 
-	if err = p.store.DeleteSubscription(subscription.SubscriptionID); err != nil {
-		p.API.LogDebug("Unable to delete the subscription from the DB", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
+	if err = p.msteamsAppClient.DeleteSubscription(subscription.SubscriptionID); err != nil {
+		p.API.LogDebug("Unable to delete the subscription on MS Teams", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
 		return &model.CommandResponse{}, nil
 	}
 
-	if err = p.msteamsAppClient.DeleteSubscription(subscription.SubscriptionID); err != nil {
-		p.API.LogDebug("Unable to delete the subscription on MS Teams", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
+	if err = p.store.DeleteSubscription(subscription.SubscriptionID); err != nil {
+		p.API.LogDebug("Unable to delete the subscription from the DB", "subscriptionID", subscription.SubscriptionID, "error", err.Error())
 	}
 
 	return &model.CommandResponse{}, nil

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -27,6 +27,7 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 		args        *model.CommandArgs
 		setupAPI    func(*plugintest.API)
 		setupStore  func(*mockStore.Store)
+		setupClient func(*mockClient.Client)
 	}{
 		{
 			description: "Successfully executed unlinked command",
@@ -45,10 +46,20 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 					ChannelId: testutils.GetChannelID(),
 					Message:   "The MS Teams channel is no longer linked to this Mattermost channel.",
 				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Times(1)
+				api.On("LogDebug", "Unable to delete the subscription from the DB", "subscriptionID", "testSubscriptionID", "error", "unable to delete the subscription").Return().Once()
 			},
 			setupStore: func(s *mockStore.Store) {
-				s.On("GetLinkByChannelID", testutils.GetChannelID()).Return(nil, nil).Once()
+				s.On("GetLinkByChannelID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					MSTeamsChannel: "Valid-MSTeamsChannel",
+				}, nil).Once()
 				s.On("DeleteLinkByChannelID", testutils.GetChannelID()).Return(nil).Times(1)
+				s.On("GetChannelSubscriptionByTeamsChannelID", "Valid-MSTeamsChannel").Return(&storemodels.ChannelSubscription{
+					SubscriptionID: "testSubscriptionID",
+				}, nil).Once()
+				s.On("DeleteSubscription", "testSubscriptionID").Return(errors.New("unable to delete the subscription")).Once()
+			},
+			setupClient: func(c *mockClient.Client) {
+				c.On("DeleteSubscription", "testSubscriptionID").Return(nil).Once()
 			},
 		},
 		{
@@ -68,10 +79,12 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 					ChannelId: "Mock-ChannelID",
 					Message:   "This Mattermost channel is not linked to any MS Teams channel.",
 				}).Return(testutils.GetPost("Mock-ChannelID", testutils.GetUserID())).Times(1)
+				api.On("LogDebug", "Unable to get the link by channel ID", "error", "Error while getting link").Return().Once()
 			},
 			setupStore: func(s *mockStore.Store) {
 				s.On("GetLinkByChannelID", "Mock-ChannelID").Return(nil, errors.New("Error while getting link")).Once()
 			},
+			setupClient: func(c *mockClient.Client) {},
 		},
 		{
 			description: "Unable to delete link.",
@@ -90,11 +103,13 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 					ChannelId: "Mock-ChannelID",
 					Message:   "Unable to delete link.",
 				}).Return(testutils.GetPost("Mock-ChannelID", testutils.GetUserID())).Times(1)
+				api.On("LogDebug", "Unable to delete the link by channel ID", "error", "Error while deleting a link").Return().Once()
 			},
 			setupStore: func(s *mockStore.Store) {
 				s.On("GetLinkByChannelID", "Mock-ChannelID").Return(nil, nil).Once()
 				s.On("DeleteLinkByChannelID", "Mock-ChannelID").Return(errors.New("Error while deleting a link")).Times(1)
 			},
+			setupClient: func(c *mockClient.Client) {},
 		},
 		{
 			description: "Unable to get the current channel",
@@ -106,7 +121,8 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 					Message: "Unable to get the current channel information.",
 				}).Return(testutils.GetPost("", "")).Times(1)
 			},
-			setupStore: func(s *mockStore.Store) {},
+			setupStore:  func(s *mockStore.Store) {},
+			setupClient: func(c *mockClient.Client) {},
 		},
 		{
 			description: "Unable to unlink channel as user is not a channel admin.",
@@ -126,7 +142,8 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 					Message:   "Unable to unlink the channel, you have to be a channel admin to unlink it.",
 				}).Return(testutils.GetPost(testutils.GetChannelID(), "bot-user-id")).Times(1)
 			},
-			setupStore: func(s *mockStore.Store) {},
+			setupStore:  func(s *mockStore.Store) {},
+			setupClient: func(c *mockClient.Client) {},
 		},
 		{
 			description: "Unable to unlink channel as channel is either a direct or group message",
@@ -145,7 +162,68 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 					Message:   "Linking/unlinking a direct or group message is not allowed",
 				}).Return(testutils.GetPost(testutils.GetChannelID(), "bot-user-id")).Times(1)
 			},
-			setupStore: func(s *mockStore.Store) {},
+			setupStore:  func(s *mockStore.Store) {},
+			setupClient: func(c *mockClient.Client) {},
+		},
+		{
+			description: "Unable to get subscription by Teams channel ID.",
+			args: &model.CommandArgs{
+				UserId:    testutils.GetUserID(),
+				ChannelId: testutils.GetChannelID(),
+			},
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Id:   testutils.GetChannelID(),
+					Type: model.ChannelTypeOpen,
+				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
+				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
+					UserId:    "bot-user-id",
+					ChannelId: testutils.GetChannelID(),
+					Message:   "The MS Teams channel is no longer linked to this Mattermost channel.",
+				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Times(1)
+				api.On("LogDebug", "Unable to get the subscription by MS Teams channel ID", "error", "unable to get the subscription").Return().Once()
+			},
+			setupStore: func(s *mockStore.Store) {
+				s.On("GetLinkByChannelID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					MSTeamsChannel: "Valid-MSTeamsChannel",
+				}, nil).Once()
+				s.On("DeleteLinkByChannelID", testutils.GetChannelID()).Return(nil).Times(1)
+				s.On("GetChannelSubscriptionByTeamsChannelID", "Valid-MSTeamsChannel").Return(nil, errors.New("unable to get the subscription")).Once()
+			},
+			setupClient: func(c *mockClient.Client) {},
+		},
+		{
+			description: "Unable to delete the subscription from Teams",
+			args: &model.CommandArgs{
+				UserId:    testutils.GetUserID(),
+				ChannelId: testutils.GetChannelID(),
+			},
+			setupAPI: func(api *plugintest.API) {
+				api.On("GetChannel", testutils.GetChannelID()).Return(&model.Channel{
+					Id:   testutils.GetChannelID(),
+					Type: model.ChannelTypeOpen,
+				}, nil).Times(1)
+				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
+				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
+					UserId:    "bot-user-id",
+					ChannelId: testutils.GetChannelID(),
+					Message:   "The MS Teams channel is no longer linked to this Mattermost channel.",
+				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Times(1)
+				api.On("LogDebug", "Unable to delete the subscription on MS Teams", "subscriptionID", "testSubscriptionID", "error", "unable to delete the subscription").Return().Once()
+			},
+			setupStore: func(s *mockStore.Store) {
+				s.On("GetLinkByChannelID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
+					MSTeamsChannel: "Valid-MSTeamsChannel",
+				}, nil).Once()
+				s.On("DeleteLinkByChannelID", testutils.GetChannelID()).Return(nil).Times(1)
+				s.On("GetChannelSubscriptionByTeamsChannelID", "Valid-MSTeamsChannel").Return(&storemodels.ChannelSubscription{
+					SubscriptionID: "testSubscriptionID",
+				}, nil).Once()
+			},
+			setupClient: func(c *mockClient.Client) {
+				c.On("DeleteSubscription", "testSubscriptionID").Return(errors.New("unable to delete the subscription")).Once()
+			},
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
@@ -153,6 +231,7 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 			p.SetAPI(mockAPI)
 
 			testCase.setupStore(p.store.(*mockStore.Store))
+			testCase.setupClient(p.msteamsAppClient.(*mockClient.Client))
 			_, _ = p.executeUnlinkCommand(testCase.args)
 		})
 	}

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -126,10 +126,12 @@ func (ah *ActivityHandler) HandleLifecycleEvent(event msteams.Activity, webhookS
 func (ah *ActivityHandler) checkSubscription(subscriptionID string) bool {
 	subscription, err := ah.plugin.GetStore().GetChannelSubscription(subscriptionID)
 	if err != nil {
+		ah.plugin.GetAPI().LogDebug("Unable to get channel subscription", "subscriptionID", subscriptionID, "error", err.Error())
 		return false
 	}
 
 	if _, err = ah.plugin.GetStore().GetLinkByMSTeamsChannelID(subscription.TeamID, subscription.ChannelID); err != nil {
+		ah.plugin.GetAPI().LogDebug("Unable to get the link by MS Teams channel ID", "error", err.Error())
 		// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
 		_ = ah.plugin.GetStore().DeleteSubscription(subscriptionID)
 		return false

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -124,47 +124,15 @@ func (ah *ActivityHandler) HandleLifecycleEvent(event msteams.Activity, webhookS
 }
 
 func (ah *ActivityHandler) checkSubscription(subscriptionID string) bool {
-	subscriptionType, err := ah.plugin.GetStore().GetSubscriptionType(subscriptionID)
+	subscription, err := ah.plugin.GetStore().GetChannelSubscription(subscriptionID)
 	if err != nil {
-		// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-		_ = ah.plugin.GetClientForApp().DeleteSubscription(subscriptionID)
 		return false
 	}
 
-	if subscriptionType == "allChats" {
-		return true
-	}
-
-	switch subscriptionType {
-	case "channel":
-		subscription, err := ah.plugin.GetStore().GetChannelSubscription(subscriptionID)
-		if err != nil {
-			// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-			_ = ah.plugin.GetClientForApp().DeleteSubscription(subscriptionID)
-			return false
-		}
-		_, err = ah.plugin.GetStore().GetLinkByMSTeamsChannelID(subscription.TeamID, subscription.ChannelID)
-		if err != nil {
-			// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-			_ = ah.plugin.GetStore().DeleteSubscription(subscriptionID)
-			// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-			_ = ah.plugin.GetClientForApp().DeleteSubscription(subscriptionID)
-			return false
-		}
-	case "chat":
-		subscription, err := ah.plugin.GetStore().GetChatSubscription(subscriptionID)
-		if err != nil {
-			// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-			_ = ah.plugin.GetClientForApp().DeleteSubscription(subscriptionID)
-			return false
-		}
-		if _, appErr := ah.plugin.GetAPI().GetUser(subscription.UserID); appErr != nil {
-			// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-			_ = ah.plugin.GetStore().DeleteSubscription(subscriptionID)
-			// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
-			_ = ah.plugin.GetClientForApp().DeleteSubscription(subscriptionID)
-			return false
-		}
+	if _, err = ah.plugin.GetStore().GetLinkByMSTeamsChannelID(subscription.TeamID, subscription.ChannelID); err != nil {
+		// Ignoring the error because can be the case that the subscription is no longer exists, in that case, it doesn't matter.
+		_ = ah.plugin.GetStore().DeleteSubscription(subscriptionID)
+		return false
 	}
 
 	return true
@@ -173,9 +141,11 @@ func (ah *ActivityHandler) checkSubscription(subscriptionID string) bool {
 func (ah *ActivityHandler) handleActivity(activity msteams.Activity) {
 	activityIds := msteams.GetResourceIds(activity.Resource)
 
-	if !ah.checkSubscription(activity.SubscriptionID) {
-		ah.plugin.GetAPI().LogError("The subscription is no longer active", "subscriptionID", activity.SubscriptionID)
-		return
+	if activityIds.ChatID == "" {
+		if !ah.checkSubscription(activity.SubscriptionID) {
+			ah.plugin.GetAPI().LogDebug("The subscription is no longer active", "subscriptionID", activity.SubscriptionID)
+			return
+		}
 	}
 
 	switch activity.ChangeType {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -124,7 +124,7 @@ func (p *Plugin) ReactionHasBeenRemoved(_ *plugin.Context, reaction *model.React
 		if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && p.getConfiguration().SyncDirectMessages {
 			err = p.UnsetChatReaction(postInfo.MSTeamsID, reaction.UserId, post.ChannelId, reaction.EmojiName)
 			if err != nil {
-				p.API.LogWarn("Unable to handle message reaction unset", "error", err.Error())
+				p.API.LogWarn("Unable to handle chat message reaction unset", "error", err.Error())
 			}
 		}
 		return

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -111,7 +111,7 @@ func (p *Plugin) ReactionHasBeenRemoved(_ *plugin.Context, reaction *model.React
 
 	post, appErr := p.API.GetPost(reaction.PostId)
 	if appErr != nil {
-		p.API.LogError("Unable to get the post from the reaction", "reaction", reaction, "error", appErr)
+		p.API.LogError("Unable to get the post from the reaction", "reaction", reaction, "error", appErr.DetailedError)
 		return
 	}
 
@@ -723,7 +723,7 @@ func (p *Plugin) UpdateChat(chatID string, user *model.User, newPost, oldPost *m
 func (p *Plugin) GetChatIDForChannel(client msteams.Client, channelID string) (string, error) {
 	channel, appErr := p.API.GetChannel(channelID)
 	if appErr != nil {
-		p.API.LogError("Unable to get MM channel", "channelID", channelID, "error", appErr.Error())
+		p.API.LogError("Unable to get MM channel", "channelID", channelID, "error", appErr.DetailedError)
 		return "", appErr
 	}
 	if channel.Type != model.ChannelTypeDirect && channel.Type != model.ChannelTypeGroup {
@@ -732,7 +732,7 @@ func (p *Plugin) GetChatIDForChannel(client msteams.Client, channelID string) (s
 
 	members, appErr := p.API.GetChannelMembers(channelID, 0, math.MaxInt32)
 	if appErr != nil {
-		p.API.LogError("Unable to get MM channel members", "channelID", channelID, "error", appErr.Error())
+		p.API.LogError("Unable to get MM channel members", "channelID", channelID, "error", appErr.DetailedError)
 		return "", appErr
 	}
 

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -40,7 +40,7 @@ func TestReactionHasBeenAdded(t *testing.T) {
 			Name: "ReactionHasBeenAdded: Unable to get the link by channel ID",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
-				api.On("LogError", "Unable to handle message reaction set", "error", mock.Anything).Times(1)
+				api.On("LogWarn", "Unable to handle message reaction set", "error", mock.Anything).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetPostInfoByMattermostID", testutils.GetID()).Return(&storemodels.PostInfo{}, nil).Times(1)
@@ -80,8 +80,8 @@ func TestReactionHasBeenAdded(t *testing.T) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
 				api.On("GetUser", testutils.GetID()).Return(testutils.GetUser(model.SystemAdminRoleId, "test@test.com"), nil).Times(1)
-				api.On("LogWarn", "Error setting reaction", "error", "unable to set the reaction")
-				api.On("LogError", "Unable to handle message reaction set", "error", "unable to set the reaction")
+				api.On("LogError", "Error setting reaction", "error", "unable to set the reaction")
+				api.On("LogWarn", "Unable to handle message reaction set", "error", "unable to set the reaction")
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetPostInfoByMattermostID", testutils.GetID()).Return(&storemodels.PostInfo{MattermostID: testutils.GetID(), MSTeamsID: "ms-teams-id", MSTeamsChannel: "ms-teams-channel-id", MSTeamsLastUpdateAt: time.UnixMicro(100)}, nil).Times(2)
@@ -185,7 +185,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		{
 			Name: "ReactionHasBeenRemoved: Unable to get the post",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to get the post from the reaction", "reaction", mock.Anything, "error", mock.Anything).Times(1)
+				api.On("LogError", "Unable to get the post from the reaction", "reaction", mock.Anything, "error", "unable to get the post").Times(1)
 				api.On("GetPost", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get the post")).Times(1)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -198,7 +198,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		{
 			Name: "ReactionHasBeenRemoved: Unable to get the link by channel ID",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to handle message reaction unset", "error", mock.Anything).Times(1)
+				api.On("LogWarn", "Unable to handle chat message reaction unset", "error", "unable to get source user ID").Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 			},
@@ -207,7 +207,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 					MattermostID: testutils.GetID(),
 				}, nil).Times(1)
 				store.On("GetLinkByChannelID", testutils.GetChannelID()).Return(nil, nil).Times(1)
-				store.On("MattermostToTeamsUserID", testutils.GetID()).Return("", testutils.GetInternalServerAppError("unable to get source user ID")).Times(1)
+				store.On("MattermostToTeamsUserID", testutils.GetID()).Return("", errors.New("unable to get source user ID")).Times(1)
 				store.On("GetDMAndGMChannelPromptTime", testutils.GetChannelID(), testutils.GetID()).Return(time.Now().Add(time.Hour*2), nil).Once()
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {},
@@ -229,8 +229,8 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		{
 			Name: "ReactionHasBeenRemoved: Unable to remove the reaction",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error in removing the reaction", "emojiName", testutils.GetReaction().EmojiName, "error", "unable to unset the reaction").Times(1)
-				api.On("LogError", "Unable to handle message reaction unset", "error", mock.Anything).Times(1)
+				api.On("LogError", "Error in removing the reaction", "emojiName", testutils.GetReaction().EmojiName, "error", "unable to unset the reaction").Times(1)
+				api.On("LogWarn", "Unable to handle message reaction unset", "error", "unable to unset the reaction").Times(1)
 				api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID()), nil).Times(1)
@@ -585,6 +585,7 @@ func TestSetChatReaction(t *testing.T) {
 			Name: "SetChatReaction: Unable to get the chat ID",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(nil, testutils.GetInternalServerAppError("unable to get the channel")).Times(1)
+				api.On("LogError", "Unable to get MM channel", "channelID", testutils.GetChannelID(), "error", "unable to get the channel")
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("MattermostToTeamsUserID", testutils.GetID()).Return(testutils.GetID(), nil).Times(1)
@@ -596,7 +597,7 @@ func TestSetChatReaction(t *testing.T) {
 		{
 			Name: "SetChatReaction: Unable to set the chat reaction",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error creating post reaction", "error", mock.Anything)
+				api.On("LogError", "Error creating post reaction", "error", mock.Anything)
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetChannelMembers", testutils.GetChannelID(), 0, math.MaxInt32).Return(testutils.GetChannelMembers(2), nil).Times(1)
 				api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("/")}}, nil).Times(2)
@@ -607,7 +608,7 @@ func TestSetChatReaction(t *testing.T) {
 			},
 			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {
 				uclient.On("CreateOrGetChatForUsers", mock.AnythingOfType("[]string")).Return(mockChat, nil).Times(1)
-				uclient.On("SetChatReaction", testutils.GetChatID(), "mockTeamsMessageID", testutils.GetID(), ":mockEmojiName:").Return(testutils.GetInternalServerAppError("unable to set the chat reaction")).Times(1)
+				uclient.On("SetChatReaction", testutils.GetChatID(), "mockTeamsMessageID", testutils.GetID(), ":mockEmojiName:").Return(errors.New("unable to set the chat reaction")).Times(1)
 			},
 			ExpectedMessage: "unable to set the chat reaction",
 		},
@@ -726,7 +727,7 @@ func TestSetReaction(t *testing.T) {
 		{
 			Name: "SetReaction: Unable to set the reaction",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error setting reaction", "error", "unable to set the reaction")
+				api.On("LogError", "Error setting reaction", "error", "unable to set the reaction")
 				api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("/")}}, nil).Times(2)
 			},
 			SetupStore: func(store *storemocks.Store) {
@@ -820,6 +821,7 @@ func TestUnsetChatReaction(t *testing.T) {
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogError", "Failed to create or get the chat", "error", mock.Anything).Return()
 				api.On("GetChannel", testutils.GetChannelID()).Return(nil, testutils.GetInternalServerAppError("unable to get the channel")).Times(1)
+				api.On("LogError", "Unable to get MM channel", "channelID", testutils.GetChannelID(), "error", "unable to get the channel")
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("MattermostToTeamsUserID", testutils.GetID()).Return(testutils.GetID(), nil).Times(1)
@@ -831,7 +833,7 @@ func TestUnsetChatReaction(t *testing.T) {
 		{
 			Name: "UnsetChatReaction: Unable to unset the chat reaction",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error in removing the chat reaction", "emojiName", "mockEmojiName", "error", ": , unable to unset the chat reaction")
+				api.On("LogError", "Error in removing the chat reaction", "emojiName", "mockEmojiName", "error", ": , unable to unset the chat reaction")
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetChannelMembers", testutils.GetChannelID(), 0, math.MaxInt32).Return(testutils.GetChannelMembers(2), nil).Times(1)
 				api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("/")}}, nil).Times(2)
@@ -963,7 +965,7 @@ func TestUnsetReaction(t *testing.T) {
 		{
 			Name: "UnsetReaction: Unable to unset the reaction",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error in removing the reaction", "emojiName", "mockName", "error", ": , unable to unset the reaction")
+				api.On("LogError", "Error in removing the reaction", "emojiName", "mockName", "error", ": , unable to unset the reaction")
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetPostInfoByMattermostID", testutils.GetID()).Return(&storemodels.PostInfo{}, nil).Times(1)
@@ -1077,7 +1079,7 @@ func TestSendChat(t *testing.T) {
 		{
 			Name: "SendChat: Unable to send the chat",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error creating post on MS Teams", "error", "unable to send the chat")
+				api.On("LogError", "Error creating post on MS Teams", "error", "unable to send the chat")
 				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
@@ -1371,7 +1373,7 @@ func TestSend(t *testing.T) {
 		{
 			Name: "Send: Unable to send message with attachments",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogWarn", "Error creating post on MS Teams", "error", "unable to send message with attachments").Times(1)
+				api.On("LogError", "Error creating post on MS Teams", "error", "unable to send message with attachments").Times(1)
 				api.On("GetFileInfo", testutils.GetID()).Return(testutils.GetFileInfo(), nil).Times(1)
 				api.On("GetFile", testutils.GetID()).Return([]byte("mockData"), nil).Times(1)
 			},
@@ -1963,6 +1965,7 @@ func TestGetChatIDForChannel(t *testing.T) {
 			Name: "GetChatIDForChannel: Unable to get the channel",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(nil, testutils.GetInternalServerAppError("unable to get the channel")).Times(1)
+				api.On("LogError", "Unable to get MM channel", "channelID", testutils.GetChannelID(), "error", "unable to get the channel")
 			},
 			SetupStore:    func(store *storemocks.Store) {},
 			SetupClient:   func(client *clientmocks.Client) {},
@@ -1982,6 +1985,7 @@ func TestGetChatIDForChannel(t *testing.T) {
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeGroup), nil).Times(1)
 				api.On("GetChannelMembers", testutils.GetChannelID(), 0, math.MaxInt32).Return(nil, testutils.GetInternalServerAppError("unable to get the channel members")).Times(1)
+				api.On("LogError", "Unable to get MM channel members", "channelID", testutils.GetChannelID(), "error", "unable to get the channel members")
 			},
 			SetupStore:    func(store *storemocks.Store) {},
 			SetupClient:   func(client *clientmocks.Client) {},
@@ -2000,23 +2004,11 @@ func TestGetChatIDForChannel(t *testing.T) {
 			ExpectedError: "unable to store the user",
 		},
 		{
-			Name: "GetChatIDForChannel: Unable to get the client",
-			SetupAPI: func(api *plugintest.API) {
-				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeGroup), nil).Times(1)
-				api.On("GetChannelMembers", testutils.GetChannelID(), 0, math.MaxInt32).Return(testutils.GetChannelMembers(2), nil).Times(1)
-			},
-			SetupStore: func(store *storemocks.Store) {
-				store.On("MattermostToTeamsUserID", testutils.GetID()).Return("mockTeamsUserID", nil).Times(2)
-				store.On("GetTokenForMattermostUser", "mockClientUserID").Return(nil, nil).Times(1)
-			},
-			SetupClient:   func(client *clientmocks.Client) {},
-			ExpectedError: "not connected user",
-		},
-		{
 			Name: "GetChatIDForChannel: Unable to create or get chat for users",
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeGroup), nil).Times(1)
 				api.On("GetChannelMembers", testutils.GetChannelID(), 0, math.MaxInt32).Return(testutils.GetChannelMembers(2), nil).Times(1)
+				api.On("LogError", "Unable to create or get chat for users", "error", "unable to create or get chat for users")
 			},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("MattermostToTeamsUserID", testutils.GetID()).Return("mockTeamsUserID", nil).Times(2)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -183,8 +183,8 @@ func TestMessageHasBeenPostedNewMessageWithFailureSending(t *testing.T) {
 	plugin.store.(*storemocks.Store).On("GetTokenForMattermostUser", "user-id").Return(&oauth2.Token{}, nil).Times(1)
 	clientMock := plugin.clientBuilderWithToken("", "", "", "", nil, nil)
 	clientMock.(*mocks.Client).On("SendMessageWithAttachments", "ms-team-id", "ms-channel-id", "", "<p>message</p>\n", []*msteams.Attachment(nil), []models.ChatMessageMentionable{}).Return(nil, errors.New("Unable to send the message"))
-	plugin.API.(*plugintest.API).On("LogWarn", "Error creating post on MS Teams", "error", "Unable to send the message").Return(nil)
-	plugin.API.(*plugintest.API).On("LogError", "Unable to handle message sent", "error", "Unable to send the message").Return(nil)
+	plugin.API.(*plugintest.API).On("LogError", "Error creating post on MS Teams", "error", "Unable to send the message").Return(nil)
+	plugin.API.(*plugintest.API).On("LogWarn", "Unable to handle message sent", "error", "Unable to send the message").Return(nil)
 
 	plugin.MessageHasBeenPosted(nil, &post)
 }

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -153,6 +153,29 @@ func (_m *Store) GetChannelSubscription(subscriptionID string) (*storemodels.Cha
 	return r0, r1
 }
 
+// GetChannelSubscriptionByTeamsChannelID provides a mock function with given fields: teamsChannelID
+func (_m *Store) GetChannelSubscriptionByTeamsChannelID(teamsChannelID string) (*storemodels.ChannelSubscription, error) {
+	ret := _m.Called(teamsChannelID)
+
+	var r0 *storemodels.ChannelSubscription
+	if rf, ok := ret.Get(0).(func(string) *storemodels.ChannelSubscription); ok {
+		r0 = rf(teamsChannelID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*storemodels.ChannelSubscription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(teamsChannelID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetChatSubscription provides a mock function with given fields: subscriptionID
 func (_m *Store) GetChatSubscription(subscriptionID string) (*storemodels.ChatSubscription, error) {
 	ret := _m.Called(subscriptionID)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -689,11 +689,9 @@ func (s *SQLStore) GetChannelSubscription(subscriptionID string) (*storemodels.C
 func (s *SQLStore) GetChannelSubscriptionByTeamsChannelID(teamsChannelID string) (*storemodels.ChannelSubscription, error) {
 	row := s.getQueryBuilder().Select("subscriptionID").From("msteamssync_subscriptions").Where(sq.Eq{"msTeamsChannelID": teamsChannelID, "type": subscriptionTypeChannel}).QueryRow()
 	var subscription storemodels.ChannelSubscription
-	var expiresOn int64
 	if scanErr := row.Scan(&subscription.SubscriptionID); scanErr != nil {
 		return nil, scanErr
 	}
-	subscription.ExpiresOn = time.UnixMicro(expiresOn)
 	return &subscription, nil
 }
 

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -62,6 +62,7 @@ type Store interface {
 	UpdateSubscriptionExpiresOn(subscriptionID string, expiresOn time.Time) error
 	DeleteSubscription(subscriptionID string) error
 	GetChannelSubscription(subscriptionID string) (*storemodels.ChannelSubscription, error)
+	GetChannelSubscriptionByTeamsChannelID(teamsChannelID string) (*storemodels.ChannelSubscription, error)
 	GetChatSubscription(subscriptionID string) (*storemodels.ChatSubscription, error)
 	GetGlobalSubscription(subscriptionID string) (*storemodels.GlobalSubscription, error)
 	GetSubscriptionType(subscriptionID string) (string, error)
@@ -679,6 +680,17 @@ func (s *SQLStore) GetChannelSubscription(subscriptionID string) (*storemodels.C
 	var subscription storemodels.ChannelSubscription
 	var expiresOn int64
 	if scanErr := row.Scan(&subscription.SubscriptionID, &subscription.ChannelID, &subscription.TeamID, &subscription.Secret, &expiresOn); scanErr != nil {
+		return nil, scanErr
+	}
+	subscription.ExpiresOn = time.UnixMicro(expiresOn)
+	return &subscription, nil
+}
+
+func (s *SQLStore) GetChannelSubscriptionByTeamsChannelID(teamsChannelID string) (*storemodels.ChannelSubscription, error) {
+	row := s.getQueryBuilder().Select("subscriptionID").From("msteamssync_subscriptions").Where(sq.Eq{"msTeamsChannelID": teamsChannelID, "type": subscriptionTypeChannel}).QueryRow()
+	var subscription storemodels.ChannelSubscription
+	var expiresOn int64
+	if scanErr := row.Scan(&subscription.SubscriptionID); scanErr != nil {
 		return nil, scanErr
 	}
 	subscription.ExpiresOn = time.UnixMicro(expiresOn)


### PR DESCRIPTION
#### Summary
- Removed the logic of deleting the subscriptions from Teams while receiving change notifications
- Created a new store function for getting channel subscription by Teams channel ID
- Added the logic of deleting the subscription from store and Teams when unlinking a channel
- Changed the log level and added several new logs in message_hooks.go file

#### Ticket Link
Fixes #269 
