### PR TITLE
Remove debug logs for message hooks

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -20,7 +20,6 @@ import (
 )
 
 func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
-	p.API.LogDebug("Create message hook", "post", post)
 	if post.Props != nil {
 		if _, ok := post.Props["msteams_sync_"+p.userID].(bool); ok {
 			return
@@ -137,7 +136,6 @@ func (p *Plugin) ReactionHasBeenRemoved(_ *plugin.Context, reaction *model.React
 }
 
 func (p *Plugin) MessageHasBeenUpdated(_ *plugin.Context, newPost, oldPost *model.Post) {
-	p.API.LogDebug("Updating message hook", "newPost", newPost, "oldPost", oldPost)
 	client, err := p.GetClientForUser(newPost.UserId)
 	if err != nil {
 		return


### PR DESCRIPTION
The message hooks fire every time a message is posted or updated in Mattermost. There is a second debug line in SendChat() that is hit when we send a message to Teams. We should only log posts when they are sent via the second logging instance.

There are other hook logs for things such as reactions. We shouldn't really log these either, but they happen less frequently so we can remove them in a follow-up if we desire.
