### PR TITLE
[MI-3479] Fixed the issue of channel mentions not working from Teams to MM

### DIFF
--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -87,7 +87,8 @@ func (ah *ActivityHandler) handleMentions(msg *msteams.Message) string {
 		mmMention := ""
 		mention := msg.Mentions[idx]
 		idx++
-		if mention.UserID != "" {
+		switch {
+		case mention.UserID != "":
 			mmUserID, err := ah.plugin.GetStore().TeamsToMattermostUserID(mention.UserID)
 			if err != nil {
 				ah.plugin.GetAPI().LogDebug("Unable to get MM user ID from Teams user ID", "TeamsUserID", mention.UserID, "Error", err.Error())
@@ -101,8 +102,10 @@ func (ah *ActivityHandler) handleMentions(msg *msteams.Message) string {
 			}
 
 			mmMention = fmt.Sprintf("@%s ", mmUser.Username)
-		} else if mention.MentionedText == "Everyone" {
+		case mention.MentionedText == "Everyone" && mention.ConversationID == msg.ChatID:
 			mmMention = "@all"
+		case mention.ConversationID == msg.ChannelID:
+			mmMention = "@channel"
 		}
 
 		if mmMention == "" {

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -128,9 +128,10 @@ type Reaction struct {
 }
 
 type Mention struct {
-	ID            int32
-	UserID        string
-	MentionedText string
+	ID             int32
+	UserID         string
+	MentionedText  string
+	ConversationID string
 }
 
 type Message struct {
@@ -1049,8 +1050,14 @@ func convertToMessage(msg models.ChatMessageable, teamID, channelID, chatID stri
 			continue
 		}
 
-		if m.GetMentioned() != nil && m.GetMentioned().GetUser() != nil && m.GetMentioned().GetUser().GetId() != nil {
-			mention.UserID = *m.GetMentioned().GetUser().GetId()
+		if m.GetMentioned() != nil {
+			if m.GetMentioned().GetUser() != nil && m.GetMentioned().GetUser().GetId() != nil {
+				mention.UserID = *m.GetMentioned().GetUser().GetId()
+			}
+
+			if m.GetMentioned().GetConversation() != nil && m.GetMentioned().GetConversation().GetId() != nil {
+				mention.ConversationID = *m.GetMentioned().GetConversation().GetId()
+			}
 		}
 
 		mentions = append(mentions, mention)


### PR DESCRIPTION
#### Summary
- Fixed the issue of channel mentions not working from Teams to MM
- Modified the struct for mention to include conversation ID as well
- Modified the logic for mentioning everyone in a GM