### PR TITLE
Fix broken link to releases page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This plugin supports the following features:
 
 ## Installation
 
-1. Go to the [releases page of this GitHub repository](github.com/mattermost/mattermost-plugin-msteams-sync/releases) and download the latest release for your Mattermost server.
+1. Go to the releases page of this GitHub repository and download the latest release for your Mattermost server: https://github.com/mattermost/mattermost-plugin-msteams-sync/releases
 2. Upload this file on the Mattermost **System Console > Plugins > Management** page to install the plugin. To learn more about how to upload a plugin, [see the documentation](https://docs.mattermost.com/administration/plugins.html#plugin-uploads).
 3. Enable the plugin from **System Console > Plugins > MSTeams Sync**.
 


### PR DESCRIPTION
Currently link redirects you to https://github.com/mattermost/mattermost-plugin-msteams-sync/blob/main/github.com/mattermost/mattermost-plugin-msteams-sync/releases

Fixed the structure to redirect to https://github.com/mattermost/mattermost-plugin-msteams-sync/releases instead