### PR TITLE
[MI-3554] Fixed the issue of emojis rendering as HTML and the connect slash command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -406,14 +406,8 @@ func (p *Plugin) GetMSTeamsChannelDetailsForAllTeams(msTeamsTeamIDsVsChannelsQue
 }
 
 func (p *Plugin) executeConnectCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	_, err := p.store.GetTokenForMattermostUser(args.UserId)
-	if err == nil {
+	if storedToken, _ := p.store.GetTokenForMattermostUser(args.UserId); storedToken != nil {
 		return p.cmdError(args.UserId, args.ChannelId, "You are already connected to MS Teams. Please disconnect your account first before connecting again.")
-	}
-
-	if !strings.Contains(err.Error(), "token not found") {
-		p.API.LogDebug("Error in getting token for Mattermost user", "UserID", args.UserId, "Error", err.Error())
-		return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
 	}
 
 	state := fmt.Sprintf("%s_%s", model.NewId(), args.UserId)
@@ -438,14 +432,8 @@ func (p *Plugin) executeConnectBotCommand(args *model.CommandArgs) (*model.Comma
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to connect the bot account, only system admins can connect the bot account.")
 	}
 
-	_, err := p.store.GetTokenForMattermostUser(p.userID)
-	if err == nil {
+	if storedToken, _ := p.store.GetTokenForMattermostUser(p.userID); storedToken != nil {
 		return p.cmdError(args.UserId, args.ChannelId, "The bot account is already connected to MS Teams. Please disconnect the bot account first before connecting again.")
-	}
-
-	if !strings.Contains(err.Error(), "token not found") {
-		p.API.LogDebug("Error in getting token for bot", "Error", err.Error())
-		return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
 	}
 
 	state := fmt.Sprintf("%s_%s", model.NewId(), p.userID)

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -881,21 +881,7 @@ func TestExecuteConnectCommand(t *testing.T) {
 				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Once()
 			},
 			setupStore: func(s *mockStore.Store) {
-				s.On("GetTokenForMattermostUser", testutils.GetUserID()).Return(nil, nil).Once()
-			},
-		},
-		{
-			description: "Unable to get user token",
-			setupAPI: func(api *plugintest.API) {
-				api.On("LogDebug", "Error in getting token for Mattermost user", "UserID", testutils.GetUserID(), "Error", "unable to get user token").Return().Once()
-				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
-					UserId:    p.userID,
-					ChannelId: testutils.GetChannelID(),
-					Message:   "Something went wrong.",
-				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Once()
-			},
-			setupStore: func(s *mockStore.Store) {
-				s.On("GetTokenForMattermostUser", testutils.GetUserID()).Return(nil, errors.New("unable to get user token")).Once()
+				s.On("GetTokenForMattermostUser", testutils.GetUserID()).Return(&oauth2.Token{}, nil).Once()
 			},
 		},
 		{
@@ -990,22 +976,7 @@ func TestExecuteConnectBotCommand(t *testing.T) {
 				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Once()
 			},
 			setupStore: func(s *mockStore.Store) {
-				s.On("GetTokenForMattermostUser", p.userID).Return(nil, nil).Once()
-			},
-		},
-		{
-			description: "Unable to get bot token",
-			setupAPI: func(api *plugintest.API) {
-				api.On("HasPermissionTo", testutils.GetUserID(), model.PermissionManageSystem).Return(true).Once()
-				api.On("LogDebug", "Error in getting token for bot", "Error", "unable to get bot token").Return().Once()
-				api.On("SendEphemeralPost", testutils.GetUserID(), &model.Post{
-					UserId:    p.userID,
-					ChannelId: testutils.GetChannelID(),
-					Message:   "Something went wrong.",
-				}).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID())).Once()
-			},
-			setupStore: func(s *mockStore.Store) {
-				s.On("GetTokenForMattermostUser", p.userID).Return(nil, errors.New("unable to get bot token")).Once()
+				s.On("GetTokenForMattermostUser", p.userID).Return(&oauth2.Token{}, nil).Once()
 			},
 		},
 		{

--- a/server/handlers/converters.go
+++ b/server/handlers/converters.go
@@ -38,9 +38,6 @@ func (ah *ActivityHandler) msgToPost(channelID, senderID string, msg *msteams.Me
 	var embeddedImages []msteams.Attachment
 	text, embeddedImages = ah.handleImages(text)
 	msg.Attachments = append(msg.Attachments, embeddedImages...)
-	if !strings.HasPrefix(text, "<p>") {
-		text = fmt.Sprintf("<p>%s</p>", text)
-	}
 	text = markdown.ConvertToMD(text)
 	props := make(map[string]interface{})
 	rootID := ""

--- a/server/handlers/converters_test.go
+++ b/server/handlers/converters_test.go
@@ -54,7 +54,7 @@ func TestMsgToPost(t *testing.T) {
 			post: &model.Post{
 				UserId:    testutils.GetSenderID(),
 				ChannelId: testutils.GetChannelID(),
-				Message:   "## Subject of the messsage\n\n\n\n",
+				Message:   "## Subject of the messsage\n",
 				Props: model.StringInterface{
 					"from_webhook":                         "true",
 					"msteams_sync_pqoejrn65psweomewmosaqr": true,

--- a/server/markdown/markdown.go
+++ b/server/markdown/markdown.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ConvertToMD(text string) string {
-	if !strings.Contains(text, "<div>") && !strings.Contains(text, "<p>") {
+	if !(strings.Contains(text, "<div") || strings.Contains(text, "<p") || strings.Contains(text, "<img")) {
 		return text
 	}
 	var sb strings.Builder

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 
 	azidentity "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/mattermost/mattermost-plugin-msteams-sync/server/markdown"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
@@ -443,7 +442,6 @@ func (tc *ClientImpl) SendChat(chatID, message string, parentMessage *Message, a
 
 	msteamsAttachments := []models.ChatMessageAttachmentable{}
 	if parentMessage != nil && parentMessage.ID != "" {
-		parentMessage.Text = markdown.ConvertToMD(parentMessage.Text)
 		contentType := "messageReference"
 		contentData, err := json.Marshal(ChatMessageAttachment{
 			MessageID:      parentMessage.ID,

--- a/server/testutils/data.go
+++ b/server/testutils/data.go
@@ -146,7 +146,7 @@ func GetPostFromTeamsMessage() *model.Post {
 	return &model.Post{
 		UserId:    GetUserID(),
 		ChannelId: GetChannelID(),
-		Message:   "mockText\n\n\n",
+		Message:   "mockText",
 		Props: model.StringInterface{
 			"msteams_sync_mock-BotUserID": true,
 		},


### PR DESCRIPTION
#### Summary
- Reverted the change in connect slash command to add additional error handling
- Removed the logic of converting the message to markdown when replying to a chat in Teams
- Fixed failing unit tests
- Modified the function ConvertToMD in markdown.go