### PR TITLE
Bump plugin version to 1.1.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "1.0.8",
+    "version": "1.1.0",
     "min_server_version": "7.8.10",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Bump plugin version to 1.1.0

#### Release notes
Supported Mattermost Server Versions: **7.8.10+**

## Enhancements
- 0eb2c41767c0270c2210db166b7e3150cb6d38b5 Added the logic of streaming files from MS Teams and uploading directly to MM without occupying memory (#298)
- 97a837aae4b753ffe59799b44ff6c712204d39dc Adding initial infrastructure for metrics (#306)
- 9c95fa6c49986c84dd45c92f95dd9cdbd9f30589 Added the logic of storing user IDs during the sync user job (#314)
- 1e28476d573da09f04778393bf3aa5b00e27e8d2 Update documentation (#321)
- 97065e34f9b067ce46eb581a51b27ebe2e8ec4b6 Update queue and workers size in handlers (#322)
- 9126c3ce77eb7537e58f549137cedead644da7d7 Fixed the issue of emojis rendering as HTML and the connect slash command (#320)

## Fixes
- 8c7e66bad650201044bdbcf69cdb07bb171bb28e Fixed the issue of emojis showing as HTML from Teams to MM (#313)
- e1ed8767ceb4cef24cc2b3c3f84620a44d52778e Removed the logic of processing post attachments on receiving update activity from MS Teams (#318)
- d5f686cdff25ac9fe87b3c97602ef6e07d492cea Fix a broken link to the releases page in README (#317)
- 4b3808ac7de95030f582990f32193303f68018fa Fix the issue of receiving multiple update activities from MS Teams (#315)
