### PR TITLE
prefer logging user ids over emails

### DIFF
--- a/server/handlers/getters.go
+++ b/server/handlers/getters.go
@@ -156,18 +156,18 @@ func (ah *ActivityHandler) getChatChannelID(chat *msteams.Chat) (string, error) 
 	for _, member := range chat.Members {
 		msteamsUser, clientErr := ah.plugin.GetClientForApp().GetUser(member.UserID)
 		if clientErr != nil {
-			ah.plugin.GetAPI().LogError("Unable to get the MS Teams user", "error", clientErr.Error())
+			ah.plugin.GetAPI().LogError("Unable to get the MS Teams user", "TeamsUserID", member.UserID, "error", clientErr.Error())
 			continue
 		}
 
 		if msteamsUser.Type == msteamsUserTypeGuest && !ah.plugin.GetSyncGuestUsers() {
 			if mmUserID, _ := ah.getOrCreateSyntheticUser(msteamsUser, false); mmUserID != "" && ah.isRemoteUser(mmUserID) {
 				if appErr := ah.plugin.GetAPI().UpdateUserActive(mmUserID, false); appErr != nil {
-					ah.plugin.GetAPI().LogDebug("Unable to deactivate user", "MMUserID", mmUserID, "Error", appErr.Error())
+					ah.plugin.GetAPI().LogDebug("Unable to deactivate user", "MMUserID", mmUserID, "TeamsUserID", msteamsUser.ID, "Error", appErr.Error())
 				}
 			}
 
-			ah.plugin.GetAPI().LogDebug("Skipping guest user while creating DM/GM", "Email", msteamsUser.Mail)
+			ah.plugin.GetAPI().LogDebug("Skipping guest user while creating DM/GM", "TeamsUserID", msteamsUser.ID)
 			continue
 		}
 

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -214,7 +214,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				client.On("GetUser", testutils.GetTeamsUserID()).Return(nil, fmt.Errorf("unable to get user")).Once()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
-				mockAPI.On("LogError", "Unable to get the MS Teams user", "error", "unable to get user").Times(1)
+				mockAPI.On("LogError", "Unable to get the MS Teams user", "TeamsUserID", mock.Anything, "error", "unable to get user").Times(1)
 				mockAPI.On("LogError", "Unable to get original channel id", "error", "not enough users for creating a channel").Times(1)
 			},
 			setupStore: func(store *mocksStore.Store) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -406,7 +406,7 @@ func (p *Plugin) syncUsers() {
 			continue
 		}
 
-		p.API.LogDebug("Running sync user job for user with email", "email", msUser.Mail)
+		p.API.LogDebug("Running sync user job for user", "TeamsUserID", msUser.ID)
 
 		mmUser, isUserPresent := mmUsersMap[msUser.Mail]
 
@@ -421,17 +421,17 @@ func (p *Plugin) syncUsers() {
 				if msUser.IsAccountEnabled {
 					// Activate the deactivated Mattermost user corresponding to the MS Teams user.
 					if mmUser.DeleteAt != 0 {
-						p.API.LogDebug("Activating the inactive user", "Email", msUser.Mail)
+						p.API.LogDebug("Activating the inactive user", "TeamsUserID", msUser.ID)
 						if err := p.API.UpdateUserActive(mmUser.Id, true); err != nil {
-							p.API.LogError("Unable to activate the user", "Email", msUser.Mail, "Error", err.Error())
+							p.API.LogError("Unable to activate the user", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "Error", err.Error())
 						}
 					}
 				} else {
 					// Deactivate the active Mattermost user corresponding to the MS Teams user.
 					if mmUser.DeleteAt == 0 {
-						p.API.LogDebug("Deactivating the Mattermost user account", "Email", msUser.Mail)
+						p.API.LogDebug("Deactivating the Mattermost user account", "TeamsUserID", msUser.ID)
 						if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
-							p.API.LogError("Unable to deactivate the Mattermost user account", "Email", mmUser.Email, "Error", err.Error())
+							p.API.LogError("Unable to deactivate the Mattermost user account", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "Error", err.Error())
 						}
 					}
 
@@ -445,13 +445,13 @@ func (p *Plugin) syncUsers() {
 			if !syncGuestUsers {
 				if isUserPresent && isRemoteUser(mmUser) {
 					// Deactivate the Mattermost user corresponding to the MS Teams guest user.
-					p.API.LogDebug("Deactivating the guest user account", "Email", msUser.Mail)
+					p.API.LogDebug("Deactivating the guest user account", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID)
 					if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
-						p.API.LogError("Unable to deactivate the guest user account", "Email", mmUser.Email, "Error", err.Error())
+						p.API.LogError("Unable to deactivate the guest user account", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "Error", err.Error())
 					}
 				} else {
 					// Skip syncing of MS Teams guest user.
-					p.API.LogDebug("Skipping syncing of the guest user", "Email", msUser.Mail)
+					p.API.LogDebug("Skipping syncing of the guest user", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID)
 				}
 
 				continue
@@ -484,7 +484,7 @@ func (p *Plugin) syncUsers() {
 						continue
 					}
 
-					p.API.LogError("Unable to create new MM user during sync job", "email", msUser.Mail, "error", appErr.Error())
+					p.API.LogError("Unable to create new MM user during sync job", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", appErr.Error())
 					break
 				}
 
@@ -502,11 +502,11 @@ func (p *Plugin) syncUsers() {
 				Value:    "0",
 			}}
 			if prefErr := p.API.UpdatePreferencesForUser(newUser.Id, preferences); prefErr != nil {
-				p.API.LogError("Unable to disable email notifications for new user", "MMUserID", newUser.Id, "error", prefErr.Error())
+				p.API.LogError("Unable to disable email notifications for new user", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", prefErr.Error())
 			}
 
 			if err = p.store.SetUserInfo(newUser.Id, msUser.ID, nil); err != nil {
-				p.API.LogError("Unable to set user info during sync user job", "email", msUser.Mail, "error", err.Error())
+				p.API.LogError("Unable to set user info during sync user job", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", err.Error())
 			}
 		} else if (username != mmUser.Username || msUser.DisplayName != mmUser.FirstName) && mmUser.RemoteId != nil {
 			mmUser.Username = username
@@ -520,7 +520,7 @@ func (p *Plugin) syncUsers() {
 						continue
 					}
 
-					p.API.LogError("Unable to update user during sync user job", "email", mmUser.Email, "error", err.Error())
+					p.API.LogError("Unable to update user during sync user job", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", err.Error())
 					break
 				}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -484,7 +484,7 @@ func (p *Plugin) syncUsers() {
 						continue
 					}
 
-					p.API.LogError("Unable to create new MM user during sync job", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", appErr.Error())
+					p.API.LogError("Unable to create new MM user during sync job", "TeamsUserID", msUser.ID, "error", appErr.Error())
 					break
 				}
 
@@ -502,11 +502,11 @@ func (p *Plugin) syncUsers() {
 				Value:    "0",
 			}}
 			if prefErr := p.API.UpdatePreferencesForUser(newUser.Id, preferences); prefErr != nil {
-				p.API.LogError("Unable to disable email notifications for new user", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", prefErr.Error())
+				p.API.LogError("Unable to disable email notifications for new user", "MMUserID", newUser.Id, "TeamsUserID", msUser.ID, "error", prefErr.Error())
 			}
 
 			if err = p.store.SetUserInfo(newUser.Id, msUser.ID, nil); err != nil {
-				p.API.LogError("Unable to set user info during sync user job", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "error", err.Error())
+				p.API.LogError("Unable to set user info during sync user job", "MMUserID", newUser.Id, "TeamsUserID", msUser.ID, "error", err.Error())
 			}
 		} else if (username != mmUser.Username || msUser.DisplayName != mmUser.FirstName) && mmUser.RemoteId != nil {
 			mmUser.Username = username

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -339,7 +339,7 @@ func TestSyncUsers(t *testing.T) {
 		{
 			Name: "SyncUsers: Unable to create the user",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to create new MM user during sync job", "email", "test@test.com", "error", mock.Anything).Times(1)
+				api.On("LogError", "Unable to create new MM user during sync job", "MMUserID", mock.Anything, "TeamsUserID", mock.Anything, "error", mock.Anything).Times(1)
 				api.On("GetUsers", &model.UserGetOptions{
 					Page:    0,
 					PerPage: math.MaxInt32,
@@ -361,7 +361,7 @@ func TestSyncUsers(t *testing.T) {
 		{
 			Name: "SyncUsers: Unable to store the user info",
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to set user info during sync user job", "email", "test@test.com", "error", mock.Anything).Times(1)
+				api.On("LogError", "Unable to set user info during sync user job", "MMUserID", mock.Anything, "TeamsUserID", mock.Anything, "error", mock.Anything).Times(1)
 				api.On("GetUsers", &model.UserGetOptions{
 					Page:    0,
 					PerPage: math.MaxInt32,


### PR DESCRIPTION
#### Summary
Prefer logging user ids over emails. For now, we follow the existing convention of naming the fields `TeamsUserID` and `MMUserID`.

#### Ticket Link
None.