### PR TITLE
metric: change event queue length & capacity

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -151,7 +151,7 @@ func NewMetrics(info InstanceInfo) *Metrics {
 
 	m.changeEventQueueLength = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   MetricsNamespace,
-		Subsystem:   MetricsSubsystemAPI,
+		Subsystem:   MetricsSubsystemApp,
 		Name:        "change_event_queue_length",
 		Help:        "The length of the change event queue.",
 		ConstLabels: additionalLabels,

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -35,6 +35,9 @@ type Metrics struct {
 	connectedUsersTotal prometheus.Gauge
 	syntheticUsersTotal prometheus.Gauge
 	linkedChannelsTotal prometheus.Gauge
+
+	changeEventQueueCapacity prometheus.Gauge
+	changeEventQueueLength   *prometheus.GaugeVec
 }
 
 // NewMetrics Factory method to create a new metrics collector.
@@ -137,6 +140,24 @@ func NewMetrics(info InstanceInfo) *Metrics {
 	})
 	m.registry.MustRegister(m.linkedChannelsTotal)
 
+	m.changeEventQueueCapacity = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   MetricsNamespace,
+		Subsystem:   MetricsSubsystemApp,
+		Name:        "change_event_queue_capacity",
+		Help:        "The capacity of the change event queue.",
+		ConstLabels: additionalLabels,
+	})
+	m.registry.MustRegister(m.changeEventQueueCapacity)
+
+	m.changeEventQueueLength = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   MetricsNamespace,
+		Subsystem:   MetricsSubsystemAPI,
+		Name:        "change_event_queue_length",
+		Help:        "The length of the change event queue.",
+		ConstLabels: additionalLabels,
+	}, []string{"change_type"})
+	m.registry.MustRegister(m.changeEventQueueLength)
+
 	return m
 }
 
@@ -191,5 +212,23 @@ func (m *Metrics) IncrementHTTPRequests() {
 func (m *Metrics) IncrementHTTPErrors() {
 	if m != nil {
 		m.httpErrorsTotal.Inc()
+	}
+}
+
+func (m *Metrics) ObserveChangeEventQueueCapacity(count int64) {
+	if m != nil {
+		m.changeEventQueueCapacity.Set(float64(count))
+	}
+}
+
+func (m *Metrics) IncrementChangeEventQueueLength(changeType string) {
+	if m != nil {
+		m.changeEventQueueLength.With(prometheus.Labels{"change_type": changeType}).Inc()
+	}
+}
+
+func (m *Metrics) DecrementChangeEventQueueLength(changeType string) {
+	if m != nil {
+		m.changeEventQueueLength.With(prometheus.Labels{"change_type": changeType}).Dec()
 	}
 }


### PR DESCRIPTION
#### Summary
Track the capacity of the change event queue (a constant, for now), as well as the length of the queue with a count for each `change_type`.

As I wrote this, I realized we have another, implicit queue of goroutines that are spawned to handle each HTTP request even if the queue is at capacity. This feels like it somewhat defeats the point of the queue, since we'll still accumulate those goroutines until we run out of memory anyway. 

I'm wondering if we should reject the HTTP request if the queue is at capacity. Thoughts? (Alternatively, we should probably at least add a metric for unqueued requests...)

#### Ticket Link
None.