### PR TITLE
Release 1.2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "min_server_version": "7.8.10",
     "server": {
         "executables": {

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -326,7 +326,11 @@ func (ah *ActivityHandler) handleUpdatedActivity(activityIds msteams.ActivityIds
 					ah.plugin.GetAPI().LogError("Unable to recover the post", "postID", postInfo.MattermostID, "error", err)
 					return
 				}
-				post, _ = ah.plugin.GetAPI().GetPost(postInfo.MattermostID)
+				post, postErr = ah.plugin.GetAPI().GetPost(postInfo.MattermostID)
+				if postErr != nil {
+					ah.plugin.GetAPI().LogError("Unable to find the original post after recovery", "postID", postInfo.MattermostID, "error", postErr.Error())
+					return
+				}
 			} else {
 				ah.plugin.GetAPI().LogError("Unable to find the original post", "error", postErr.Error())
 				return

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -432,7 +432,7 @@ func (p *Plugin) syncUsers() {
 					if mmUser.DeleteAt == 0 {
 						p.API.LogDebug("Deactivating the Mattermost user account", "TeamsUserID", msUser.ID)
 						if err := p.API.UpdateUserActive(mmUser.Id, false); err != nil {
-							p.API.LogError("Unable to deactivate the Mattermost user account", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID, "Error", err.Error())
+							p.API.LogError("Unable to deactivate the Mattermost user account", "TeamsUserID", msUser.ID, "Error", err.Error())
 						}
 					}
 

--- a/server/store/store_test.go
+++ b/server/store/store_test.go
@@ -793,6 +793,7 @@ func testListChannelSubscriptionsToRefresh(t *testing.T, store *SQLStore, _ *plu
 			require.NoError(t, err)
 		}()
 
+		time.Sleep(1 * time.Second)
 		_, err := store.GetChannelSubscription("test")
 		require.NoError(t, err)
 


### PR DESCRIPTION
#### Summary
Some of my recent logging changes failed to take into account the code paths in which `mmUser` was `nil`. One of those was found and fixed in v1.2.1, this fixes the other.

#### Ticket Link
None.