### PR TITLE
Fix mmUser == nil panic

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -452,7 +452,7 @@ func (p *Plugin) syncUsers() {
 					}
 				} else {
 					// Skip syncing of MS Teams guest user.
-					p.API.LogDebug("Skipping syncing of the guest user", "MMUserID", mmUser.Id, "TeamsUserID", msUser.ID)
+					p.API.LogDebug("Skipping syncing of the guest user", "TeamsUserID", msUser.ID)
 				}
 
 				continue


### PR DESCRIPTION
#### Summary
Some of my recent logging changes failed to take into account the code paths in which `mmUser` was `nil`. One of those was found and fixed in v1.2.1, this fixes the other.

#### Ticket Link
None.