### PR TITLE
support nil-metrics

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -40,7 +40,7 @@ func NewAPI(p *Plugin, store store.Store) *API {
 	router := mux.NewRouter()
 	api := &API{p: p, router: router, store: store}
 
-	if p.metricsService != nil {
+	if p.GetMetrics() != nil {
 		// set error counter middleware handler
 		router.Use(api.metricsMiddleware)
 	}
@@ -114,7 +114,7 @@ func (a *API) processActivity(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		a.p.metricsService.ObserveChangeEventTotal(activity.ChangeType)
+		a.p.GetMetrics().ObserveChangeEventTotal(activity.ChangeType)
 		if err := a.p.activityHandler.Handle(activity); err != nil {
 			a.p.API.LogError("Unable to process created activity", "activity", activity, "error", err.Error())
 			errors += err.Error() + "\n"
@@ -153,7 +153,7 @@ func (a *API) processLifecycle(w http.ResponseWriter, req *http.Request) {
 			a.p.API.LogError("Invalid webhook secret received in lifecycle event")
 			continue
 		}
-		a.p.metricsService.ObserveLifecycleEventTotal(event.LifecycleEvent)
+		a.p.GetMetrics().ObserveLifecycleEventTotal(event.LifecycleEvent)
 		a.p.activityHandler.HandleLifecycleEvent(event)
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -114,9 +114,7 @@ func (a *API) processActivity(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		if a.p.metricsService != nil {
-			a.p.metricsService.ObserveChangeEventTotal(activity.ChangeType)
-		}
+		a.p.metricsService.ObserveChangeEventTotal(activity.ChangeType)
 		if err := a.p.activityHandler.Handle(activity); err != nil {
 			a.p.API.LogError("Unable to process created activity", "activity", activity, "error", err.Error())
 			errors += err.Error() + "\n"
@@ -155,9 +153,7 @@ func (a *API) processLifecycle(w http.ResponseWriter, req *http.Request) {
 			a.p.API.LogError("Invalid webhook secret received in lifecycle event")
 			continue
 		}
-		if a.p.metricsService != nil {
-			a.p.metricsService.ObserveLifecycleEventTotal(event.LifecycleEvent)
-		}
+		a.p.metricsService.ObserveLifecycleEventTotal(event.LifecycleEvent)
 		a.p.activityHandler.HandleLifecycleEvent(event)
 	}
 

--- a/server/command.go
+++ b/server/command.go
@@ -203,7 +203,7 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to subscribe to the channel")
 	}
 
-	p.metricsService.ObserveSubscriptionsCount(metrics.SubscriptionConnected)
+	p.GetMetrics().ObserveSubscriptionsCount(metrics.SubscriptionConnected)
 	if err = p.store.StoreChannelLink(&channelLink); err != nil {
 		p.API.LogDebug("Unable to create the new link", "error", err.Error())
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to create new link.")

--- a/server/command.go
+++ b/server/command.go
@@ -203,9 +203,7 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to subscribe to the channel")
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveSubscriptionsCount(metrics.SubscriptionConnected)
-	}
+	p.metricsService.ObserveSubscriptionsCount(metrics.SubscriptionConnected)
 	if err = p.store.StoreChannelLink(&channelLink); err != nil {
 		p.API.LogDebug("Unable to create the new link", "error", err.Error())
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to create new link.")

--- a/server/handlers/attachments_test.go
+++ b/server/handlers/attachments_test.go
@@ -274,7 +274,7 @@ func TestHandleAttachments(t *testing.T) {
 				p.On("GetClientForApp").Return(client).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(2)
 				p.On("GetMaxSizeForCompleteDownload").Return(1).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetConfig").Return(&model.Config{
@@ -324,7 +324,7 @@ func TestHandleAttachments(t *testing.T) {
 				p.On("GetClientForApp").Return(client).Once()
 				p.On("GetAPI").Return(mockAPI).Times(3)
 				p.On("GetMaxSizeForCompleteDownload").Return(1).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetConfig").Return(&model.Config{
@@ -355,7 +355,7 @@ func TestHandleAttachments(t *testing.T) {
 				p.On("GetClientForApp").Return(client).Once()
 				p.On("GetAPI").Return(mockAPI)
 				p.On("GetMaxSizeForCompleteDownload").Return(1).Times(10)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetConfig").Return(&model.Config{
@@ -384,7 +384,7 @@ func TestHandleAttachments(t *testing.T) {
 			description: "Attachment type code snippet",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
 				p.On("GetClientForApp").Return(client)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetConfig").Return(&model.Config{
@@ -410,7 +410,7 @@ func TestHandleAttachments(t *testing.T) {
 		{
 			description: "Attachment type message reference",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 				p.On("GetClientForApp").Return(client)
 				p.On("GetStore").Return(store, nil)
 				p.On("GetAPI").Return(mockAPI)

--- a/server/handlers/converters_test.go
+++ b/server/handlers/converters_test.go
@@ -52,7 +52,7 @@ func TestMsgToPost(t *testing.T) {
 				p.On("GetBotUserID").Return(testutils.GetSenderID())
 				p.On("GetURL").Return("https://example.com/")
 				p.On("GetClientForApp").Return(client)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(api *plugintest.API) {
 				api.On("LogDebug", "Unable to get user avatar", "Error", mock.Anything).Once()

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -119,7 +119,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(2)
 				p.On("GetStore").Return(store).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -162,7 +162,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetAPI").Return(mockAPI).Times(2)
 				p.On("GetStore").Return(store).Times(2)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -205,7 +205,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Times(2)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -250,7 +250,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Times(5)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -300,7 +300,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Times(5)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(2)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -352,7 +352,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Times(6)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(2)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -413,7 +413,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Times(6)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(2)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -472,7 +472,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetAPI").Return(mockAPI).Times(5)
 				p.On("GetStore").Return(store).Times(5)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
-				p.On("GetMetrics").Return(mockmetrics).Times(2)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetMessage", "mockTeamID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&clientmodels.Message{
@@ -806,7 +806,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				p.On("GetBotUserID").Return(testutils.GetSenderID()).Times(2)
 				p.On("GetSyncDirectMessages").Return(true).Once()
-				p.On("GetMetrics").Return(mockmetrics).Times(2)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -860,7 +860,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Times(4)
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				p.On("GetBotUserID").Return(testutils.GetSenderID()).Times(2)
-				p.On("GetMetrics").Return(mockmetrics).Times(2)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetMessage", "mockTeamID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&clientmodels.Message{
@@ -936,7 +936,7 @@ func TestHandleDeletedActivity(t *testing.T) {
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
 				p.On("GetStore").Return(store).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(1)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("DeletePost", testutils.GetMattermostID()).Return(nil).Times(1)
@@ -1058,7 +1058,7 @@ func TestHandleReactions(t *testing.T) {
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
 				p.On("GetStore").Return(store).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(5)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetReactions", testutils.GetPostID()).Return([]*model.Reaction{
@@ -1097,7 +1097,7 @@ func TestHandleReactions(t *testing.T) {
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
 				p.On("GetStore").Return(store).Times(1)
 				p.On("GetAPI").Return(mockAPI).Times(6)
-				p.On("GetMetrics").Return(mockmetrics).Times(1)
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
 				mockAPI.On("GetReactions", testutils.GetPostID()).Return([]*model.Reaction{

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -253,7 +253,7 @@ func (p *Plugin) SetChatReaction(teamsMessageID, srcUser, channelID, emojiName s
 			return txErr
 		}
 
-		p.metricsService.ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, true)
+		p.GetMetrics().ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, true)
 	} else {
 		teamsMessage, txErr = client.GetChatMessage(chatID, teamsMessageID)
 		if txErr != nil {
@@ -326,7 +326,7 @@ func (p *Plugin) SetReaction(teamID, channelID, userID string, post *model.Post,
 			return txErr
 		}
 
-		p.metricsService.ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, false)
+		p.GetMetrics().ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, false)
 	} else {
 		teamsMessage, txErr = getUpdatedMessage(teamID, channelID, parentID, postInfo.MSTeamsID, client)
 		if txErr != nil {
@@ -391,7 +391,7 @@ func (p *Plugin) UnsetChatReaction(teamsMessageID, srcUser, channelID string, em
 		return txErr
 	}
 
-	p.metricsService.ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, true)
+	p.GetMetrics().ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, true)
 	if txErr = p.store.SetPostLastUpdateAtByMSTeamsID(tx, teamsMessageID, teamsMessage.LastUpdateAt); txErr != nil {
 		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", txErr.Error())
 	}
@@ -454,7 +454,7 @@ func (p *Plugin) UnsetReaction(teamID, channelID, userID string, post *model.Pos
 		return txErr
 	}
 
-	p.metricsService.ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false)
+	p.GetMetrics().ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false)
 	if txErr = p.store.SetPostLastUpdateAtByMattermostID(tx, postInfo.MattermostID, teamsMessage.LastUpdateAt); txErr != nil {
 		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", txErr.Error())
 	}
@@ -510,13 +510,13 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
 			p.API.LogWarn("Unable to get file info", "error", appErr)
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
+			p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
 			continue
 		}
 		fileData, appErr := p.API.GetFile(fileInfo.Id)
 		if appErr != nil {
 			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
+			p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
 			continue
 		}
 
@@ -525,11 +525,11 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		attachment, err = client.UploadFile("", "", fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), chat)
 		if err != nil {
 			p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, true)
+			p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, true)
 			continue
 		}
 		attachments = append(attachments, attachment)
-		p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
+		p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))
@@ -551,7 +551,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		return "", err
 	}
 
-	p.metricsService.ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, true)
+	p.GetMetrics().ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, true)
 	if post.Id != "" {
 		if err := p.store.LinkPosts(nil, storemodels.PostInfo{MattermostID: post.Id, MSTeamsChannel: chat.ID, MSTeamsID: newMessage.ID, MSTeamsLastUpdateAt: newMessage.LastUpdateAt}); err != nil {
 			p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
@@ -606,13 +606,13 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
 			p.API.LogWarn("Unable to get file info", "error", appErr)
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
+			p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
 			continue
 		}
 		fileData, appErr := p.API.GetFile(fileInfo.Id)
 		if appErr != nil {
 			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
+			p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
 			continue
 		}
 
@@ -621,11 +621,11 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		attachment, err = client.UploadFile(teamID, channelID, fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), nil)
 		if err != nil {
 			p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, false)
+			p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, false)
 			continue
 		}
 		attachments = append(attachments, attachment)
-		p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
+		p.GetMetrics().ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))
@@ -639,7 +639,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		return "", err
 	}
 
-	p.metricsService.ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, false)
+	p.GetMetrics().ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, false)
 	if post.Id != "" {
 		if err := p.store.LinkPosts(nil, storemodels.PostInfo{MattermostID: post.Id, MSTeamsChannel: channelID, MSTeamsID: newMessage.ID, MSTeamsLastUpdateAt: newMessage.LastUpdateAt}); err != nil {
 			p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
@@ -683,7 +683,7 @@ func (p *Plugin) Delete(teamID, channelID string, user *model.User, post *model.
 		return err
 	}
 
-	p.metricsService.ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, false)
+	p.GetMetrics().ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, false)
 	return nil
 }
 
@@ -712,7 +712,7 @@ func (p *Plugin) DeleteChat(chatID string, user *model.User, post *model.Post) e
 		return err
 	}
 
-	p.metricsService.ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, true)
+	p.GetMetrics().ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, true)
 	return nil
 }
 
@@ -788,7 +788,7 @@ func (p *Plugin) Update(teamID, channelID string, user *model.User, newPost, old
 			}
 		}
 
-		p.metricsService.ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, false)
+		p.GetMetrics().ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, false)
 	} else {
 		updatedMessage, txErr = getUpdatedMessage(teamID, channelID, parentID, postInfo.MSTeamsID, client)
 		if txErr != nil {
@@ -863,7 +863,7 @@ func (p *Plugin) UpdateChat(chatID string, user *model.User, newPost, oldPost *m
 			}
 		}
 
-		p.metricsService.ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, true)
+		p.GetMetrics().ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, true)
 	} else {
 		updatedMessage, txErr = client.GetChatMessage(chatID, postInfo.MSTeamsID)
 		if txErr != nil {

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -253,9 +253,7 @@ func (p *Plugin) SetChatReaction(teamsMessageID, srcUser, channelID, emojiName s
 			return txErr
 		}
 
-		if p.metricsService != nil {
-			p.metricsService.ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, true)
-		}
+		p.metricsService.ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, true)
 	} else {
 		teamsMessage, txErr = client.GetChatMessage(chatID, teamsMessageID)
 		if txErr != nil {
@@ -328,9 +326,7 @@ func (p *Plugin) SetReaction(teamID, channelID, userID string, post *model.Post,
 			return txErr
 		}
 
-		if p.metricsService != nil {
-			p.metricsService.ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, false)
-		}
+		p.metricsService.ObserveReactionsCount(metrics.ReactionSetAction, metrics.ActionSourceMattermost, false)
 	} else {
 		teamsMessage, txErr = getUpdatedMessage(teamID, channelID, parentID, postInfo.MSTeamsID, client)
 		if txErr != nil {
@@ -395,9 +391,7 @@ func (p *Plugin) UnsetChatReaction(teamsMessageID, srcUser, channelID string, em
 		return txErr
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, true)
-	}
+	p.metricsService.ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, true)
 	if txErr = p.store.SetPostLastUpdateAtByMSTeamsID(tx, teamsMessageID, teamsMessage.LastUpdateAt); txErr != nil {
 		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", txErr.Error())
 	}
@@ -460,9 +454,7 @@ func (p *Plugin) UnsetReaction(teamID, channelID, userID string, post *model.Pos
 		return txErr
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false)
-	}
+	p.metricsService.ObserveReactionsCount(metrics.ReactionUnsetAction, metrics.ActionSourceMattermost, false)
 	if txErr = p.store.SetPostLastUpdateAtByMattermostID(tx, postInfo.MattermostID, teamsMessage.LastUpdateAt); txErr != nil {
 		p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", txErr.Error())
 	}
@@ -518,17 +510,13 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
 			p.API.LogWarn("Unable to get file info", "error", appErr)
-			if p.metricsService != nil {
-				p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
-			}
+			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
 			continue
 		}
 		fileData, appErr := p.API.GetFile(fileInfo.Id)
 		if appErr != nil {
 			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
-			if p.metricsService != nil {
-				p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
-			}
+			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, true)
 			continue
 		}
 
@@ -537,15 +525,11 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		attachment, err = client.UploadFile("", "", fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), chat)
 		if err != nil {
 			p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
-			if p.metricsService != nil {
-				p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, true)
-			}
+			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, true)
 			continue
 		}
 		attachments = append(attachments, attachment)
-		if p.metricsService != nil {
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
-		}
+		p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", true)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))
@@ -567,9 +551,7 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 		return "", err
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, true)
-	}
+	p.metricsService.ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, true)
 	if post.Id != "" {
 		if err := p.store.LinkPosts(nil, storemodels.PostInfo{MattermostID: post.Id, MSTeamsChannel: chat.ID, MSTeamsID: newMessage.ID, MSTeamsLastUpdateAt: newMessage.LastUpdateAt}); err != nil {
 			p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
@@ -624,17 +606,13 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
 			p.API.LogWarn("Unable to get file info", "error", appErr)
-			if p.metricsService != nil {
-				p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
-			}
+			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
 			continue
 		}
 		fileData, appErr := p.API.GetFile(fileInfo.Id)
 		if appErr != nil {
 			p.API.LogWarn("Error in getting file attachment from Mattermost", "error", appErr)
-			if p.metricsService != nil {
-				p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
-			}
+			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToGetMMData, false)
 			continue
 		}
 
@@ -643,15 +621,11 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		attachment, err = client.UploadFile(teamID, channelID, fileName+"_"+fileInfo.Id+fileExtension, int(fileInfo.Size), fileInfo.MimeType, bytes.NewReader(fileData), nil)
 		if err != nil {
 			p.API.LogWarn("Error in uploading file attachment to MS Teams", "error", err)
-			if p.metricsService != nil {
-				p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, false)
-			}
+			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, discardedReasonUnableToUploadFileOnTeams, false)
 			continue
 		}
 		attachments = append(attachments, attachment)
-		if p.metricsService != nil {
-			p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
-		}
+		p.metricsService.ObserveFileCount(metrics.ActionCreated, metrics.ActionSourceMattermost, "", false)
 	}
 
 	md := markdown.New(markdown.XHTMLOutput(true), markdown.Typographer(false))
@@ -665,9 +639,7 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 		return "", err
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, false)
-	}
+	p.metricsService.ObserveMessagesCount(metrics.ActionCreated, metrics.ActionSourceMattermost, false)
 	if post.Id != "" {
 		if err := p.store.LinkPosts(nil, storemodels.PostInfo{MattermostID: post.Id, MSTeamsChannel: channelID, MSTeamsID: newMessage.ID, MSTeamsLastUpdateAt: newMessage.LastUpdateAt}); err != nil {
 			p.API.LogWarn("Error updating the msteams/mattermost post link metadata", "error", err)
@@ -711,9 +683,7 @@ func (p *Plugin) Delete(teamID, channelID string, user *model.User, post *model.
 		return err
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, false)
-	}
+	p.metricsService.ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, false)
 	return nil
 }
 
@@ -742,9 +712,7 @@ func (p *Plugin) DeleteChat(chatID string, user *model.User, post *model.Post) e
 		return err
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, true)
-	}
+	p.metricsService.ObserveMessagesCount(metrics.ActionDeleted, metrics.ActionSourceMattermost, true)
 	return nil
 }
 
@@ -820,9 +788,7 @@ func (p *Plugin) Update(teamID, channelID string, user *model.User, newPost, old
 			}
 		}
 
-		if p.metricsService != nil {
-			p.metricsService.ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, false)
-		}
+		p.metricsService.ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, false)
 	} else {
 		updatedMessage, txErr = getUpdatedMessage(teamID, channelID, parentID, postInfo.MSTeamsID, client)
 		if txErr != nil {
@@ -897,9 +863,7 @@ func (p *Plugin) UpdateChat(chatID string, user *model.User, newPost, oldPost *m
 			}
 		}
 
-		if p.metricsService != nil {
-			p.metricsService.ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, true)
-		}
+		p.metricsService.ObserveMessagesCount(metrics.ActionUpdated, metrics.ActionSourceMattermost, true)
 	} else {
 		updatedMessage, txErr = client.GetChatMessage(chatID, postInfo.MSTeamsID)
 		if txErr != nil {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -102,14 +102,6 @@ type metrics struct {
 	changeEventQueueLength   *prometheus.GaugeVec
 }
 
-// NilMetrics returns the Metrics interface with a concrete, but nil value. Since all methods on
-// the metrics type are safe to call with a nil receiver, this gives the caller a "no-op" version
-// of the metrics interface to use when metrics are disabled.
-func NilMetrics() Metrics {
-	var m *metrics
-	return m
-}
-
 // NewMetrics Factory method to create a new metrics collector.
 func NewMetrics(info InstanceInfo) Metrics {
 	m := &metrics{}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -99,6 +99,14 @@ type metrics struct {
 	storeTimesHistograms *prometheus.HistogramVec
 }
 
+// NilMetrics returns the Metrics interface with a concrete, but nil value. Since all methods on
+// the metrics type are safe to call with a nil receiver, this gives the caller a "no-op" version
+// of the metrics interface to use when metrics are disabled.
+func NilMetrics() Metrics {
+	var m *metrics
+	return m
+}
+
 // NewMetrics Factory method to create a new metrics collector.
 func NewMetrics(info InstanceInfo) Metrics {
 	m := &metrics{}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -20,34 +20,30 @@ func (r *StatusRecorder) WriteHeader(status int) {
 
 func (a *API) metricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if a.p.GetMetrics() != nil {
-			a.p.GetMetrics().IncrementHTTPRequests()
-			recorder := &StatusRecorder{
-				ResponseWriter: w,
-				Status:         http.StatusOK,
-			}
-
-			now := time.Now()
-			next.ServeHTTP(recorder, r)
-			elapsed := float64(time.Since(now)) / float64(time.Second)
-
-			if recorder.Status < 200 || recorder.Status > 299 {
-				a.p.GetMetrics().IncrementHTTPErrors()
-			}
-
-			var routeMatch mux.RouteMatch
-			a.router.Match(r, &routeMatch)
-			endpoint := "unknown"
-			if routeMatch.Route != nil {
-				var err error
-				endpoint, err = routeMatch.Route.GetPathTemplate()
-				if err != nil {
-					endpoint = "unknown"
-				}
-			}
-			a.p.GetMetrics().ObserveAPIEndpointDuration(endpoint, r.Method, strconv.Itoa(recorder.Status), elapsed)
-		} else {
-			next.ServeHTTP(w, r)
+		a.p.GetMetrics().IncrementHTTPRequests()
+		recorder := &StatusRecorder{
+			ResponseWriter: w,
+			Status:         http.StatusOK,
 		}
+
+		now := time.Now()
+		next.ServeHTTP(recorder, r)
+		elapsed := float64(time.Since(now)) / float64(time.Second)
+
+		if recorder.Status < 200 || recorder.Status > 299 {
+			a.p.GetMetrics().IncrementHTTPErrors()
+		}
+
+		var routeMatch mux.RouteMatch
+		a.router.Match(r, &routeMatch)
+		endpoint := "unknown"
+		if routeMatch.Route != nil {
+			var err error
+			endpoint, err = routeMatch.Route.GetPathTemplate()
+			if err != nil {
+				endpoint = "unknown"
+			}
+		}
+		a.p.GetMetrics().ObserveAPIEndpointDuration(endpoint, r.Method, strconv.Itoa(recorder.Status), elapsed)
 	})
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -20,8 +20,8 @@ func (r *StatusRecorder) WriteHeader(status int) {
 
 func (a *API) metricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if a.p.metricsService != nil {
-			a.p.metricsService.IncrementHTTPRequests()
+		if a.p.GetMetrics() != nil {
+			a.p.GetMetrics().IncrementHTTPRequests()
 			recorder := &StatusRecorder{
 				ResponseWriter: w,
 				Status:         http.StatusOK,
@@ -32,7 +32,7 @@ func (a *API) metricsMiddleware(next http.Handler) http.Handler {
 			elapsed := float64(time.Since(now)) / float64(time.Second)
 
 			if recorder.Status < 200 || recorder.Status > 299 {
-				a.p.metricsService.IncrementHTTPErrors()
+				a.p.GetMetrics().IncrementHTTPErrors()
 			}
 
 			var routeMatch mux.RouteMatch
@@ -45,7 +45,7 @@ func (a *API) metricsMiddleware(next http.Handler) http.Handler {
 					endpoint = "unknown"
 				}
 			}
-			a.p.metricsService.ObserveAPIEndpointDuration(endpoint, r.Method, strconv.Itoa(recorder.Status), elapsed)
+			a.p.GetMetrics().ObserveAPIEndpointDuration(endpoint, r.Method, strconv.Itoa(recorder.Status), elapsed)
 		} else {
 			next.ServeHTTP(w, r)
 		}

--- a/server/monitor/subscriptions.go
+++ b/server/monitor/subscriptions.go
@@ -135,9 +135,8 @@ func (m *Monitor) CreateAndSaveChatSubscription(mmSubscription *storemodels.Glob
 		return
 	}
 
-	if m.metrics != nil {
-		m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionConnected)
-	}
+	m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionConnected)
+
 	if mmSubscription != nil {
 		if err := m.store.DeleteSubscription(mmSubscription.SubscriptionID); err != nil {
 			m.api.LogError("Unable to delete the old all chats subscription", "error", err.Error())
@@ -176,9 +175,8 @@ func (m *Monitor) recreateChannelSubscription(subscriptionID, teamID, channelID,
 		return
 	}
 
-	if m.metrics != nil {
-		m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionReconnected)
-	}
+	m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionReconnected)
+
 	if subscriptionID != "" {
 		if err = m.store.DeleteSubscription(subscriptionID); err != nil {
 			m.api.LogDebug("Unable to delete old channel subscription from DB", "subscriptionID", subscriptionID, "error", err.Error())
@@ -221,9 +219,8 @@ func (m *Monitor) recreateGlobalSubscription(subscriptionID, secret string) erro
 		return err
 	}
 
-	if m.metrics != nil {
-		m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionReconnected)
-	}
+	m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionReconnected)
+
 	if err = m.store.DeleteSubscription(subscriptionID); err != nil {
 		m.api.LogDebug("Unable to delete old global subscription from DB", "subscriptionID", subscriptionID, "error", err.Error())
 	}
@@ -236,9 +233,8 @@ func (m *Monitor) refreshSubscription(subscriptionID string) error {
 		return err
 	}
 
-	if m.metrics != nil {
-		m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionRefreshed)
-	}
+	m.metrics.ObserveSubscriptionsCount(metrics.SubscriptionRefreshed)
+
 	return m.store.UpdateSubscriptionExpiresOn(subscriptionID, *newSubscriptionTime)
 }
 

--- a/server/msteams/client_timerlayer/timerlayer.go
+++ b/server/msteams/client_timerlayer/timerlayer.go
@@ -32,9 +32,7 @@ func (c *ClientTimerLayer) Connect() error {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.Connect", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.Connect", success, elapsed)
 	return err
 }
 
@@ -48,9 +46,7 @@ func (c *ClientTimerLayer) CreateOrGetChatForUsers(usersIDs []string) (*clientmo
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.CreateOrGetChatForUsers", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.CreateOrGetChatForUsers", success, elapsed)
 	return result, err
 }
 
@@ -64,9 +60,7 @@ func (c *ClientTimerLayer) DeleteChatMessage(chatID string, msgID string) error 
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteChatMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteChatMessage", success, elapsed)
 	return err
 }
 
@@ -80,9 +74,7 @@ func (c *ClientTimerLayer) DeleteMessage(teamID string, channelID string, parent
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteMessage", success, elapsed)
 	return err
 }
 
@@ -96,9 +88,7 @@ func (c *ClientTimerLayer) DeleteSubscription(subscriptionID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteSubscription", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.DeleteSubscription", success, elapsed)
 	return err
 }
 
@@ -112,9 +102,7 @@ func (c *ClientTimerLayer) GetChannelInTeam(teamID string, channelID string) (*c
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelInTeam", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelInTeam", success, elapsed)
 	return result, err
 }
 
@@ -128,9 +116,7 @@ func (c *ClientTimerLayer) GetChannelsInTeam(teamID string, filterQuery string) 
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelsInTeam", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChannelsInTeam", success, elapsed)
 	return result, err
 }
 
@@ -144,9 +130,7 @@ func (c *ClientTimerLayer) GetChat(chatID string) (*clientmodels.Chat, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChat", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChat", success, elapsed)
 	return result, err
 }
 
@@ -160,9 +144,7 @@ func (c *ClientTimerLayer) GetChatMessage(chatID string, messageID string) (*cli
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChatMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetChatMessage", success, elapsed)
 	return result, err
 }
 
@@ -176,9 +158,7 @@ func (c *ClientTimerLayer) GetCodeSnippet(url string) (string, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetCodeSnippet", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetCodeSnippet", success, elapsed)
 	return result, err
 }
 
@@ -192,9 +172,7 @@ func (c *ClientTimerLayer) GetFileContent(downloadURL string) ([]byte, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContent", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContent", success, elapsed)
 	return result, err
 }
 
@@ -208,9 +186,7 @@ func (c *ClientTimerLayer) GetFileContentStream(downloadURL string, writer *io.P
 	if true {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContentStream", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileContentStream", success, elapsed)
 
 }
 
@@ -224,9 +200,7 @@ func (c *ClientTimerLayer) GetFileSizeAndDownloadURL(weburl string) (int64, stri
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileSizeAndDownloadURL", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetFileSizeAndDownloadURL", success, elapsed)
 	return result, resultVar1, err
 }
 
@@ -240,9 +214,7 @@ func (c *ClientTimerLayer) GetHostedFileContent(activityIDs *clientmodels.Activi
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetHostedFileContent", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetHostedFileContent", success, elapsed)
 	return result, err
 }
 
@@ -256,9 +228,7 @@ func (c *ClientTimerLayer) GetMe() (*clientmodels.User, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMe", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMe", success, elapsed)
 	return result, err
 }
 
@@ -272,9 +242,7 @@ func (c *ClientTimerLayer) GetMessage(teamID string, channelID string, messageID
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMessage", success, elapsed)
 	return result, err
 }
 
@@ -288,9 +256,7 @@ func (c *ClientTimerLayer) GetMyID() (string, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMyID", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetMyID", success, elapsed)
 	return result, err
 }
 
@@ -304,9 +270,7 @@ func (c *ClientTimerLayer) GetReply(teamID string, channelID string, messageID s
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetReply", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetReply", success, elapsed)
 	return result, err
 }
 
@@ -320,9 +284,7 @@ func (c *ClientTimerLayer) GetTeam(teamID string) (*clientmodels.Team, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeam", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeam", success, elapsed)
 	return result, err
 }
 
@@ -336,9 +298,7 @@ func (c *ClientTimerLayer) GetTeams(filterQuery string) ([]*clientmodels.Team, e
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeams", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetTeams", success, elapsed)
 	return result, err
 }
 
@@ -352,9 +312,7 @@ func (c *ClientTimerLayer) GetUser(userID string) (*clientmodels.User, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUser", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUser", success, elapsed)
 	return result, err
 }
 
@@ -368,9 +326,7 @@ func (c *ClientTimerLayer) GetUserAvatar(userID string) ([]byte, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUserAvatar", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.GetUserAvatar", success, elapsed)
 	return result, err
 }
 
@@ -384,9 +340,7 @@ func (c *ClientTimerLayer) ListChannels(teamID string) ([]clientmodels.Channel, 
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChannels", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListChannels", success, elapsed)
 	return result, err
 }
 
@@ -400,9 +354,7 @@ func (c *ClientTimerLayer) ListSubscriptions() ([]*clientmodels.Subscription, er
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.ListSubscriptions", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListSubscriptions", success, elapsed)
 	return result, err
 }
 
@@ -416,9 +368,7 @@ func (c *ClientTimerLayer) ListTeams() ([]clientmodels.Team, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.ListTeams", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListTeams", success, elapsed)
 	return result, err
 }
 
@@ -432,9 +382,7 @@ func (c *ClientTimerLayer) ListUsers() ([]clientmodels.User, error) {
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.ListUsers", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.ListUsers", success, elapsed)
 	return result, err
 }
 
@@ -448,9 +396,7 @@ func (c *ClientTimerLayer) RefreshSubscription(subscriptionID string) (*time.Tim
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.RefreshSubscription", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.RefreshSubscription", success, elapsed)
 	return result, err
 }
 
@@ -464,9 +410,7 @@ func (c *ClientTimerLayer) SendChat(chatID string, message string, parentMessage
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SendChat", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendChat", success, elapsed)
 	return result, err
 }
 
@@ -480,9 +424,7 @@ func (c *ClientTimerLayer) SendMessage(teamID string, channelID string, parentID
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessage", success, elapsed)
 	return result, err
 }
 
@@ -496,9 +438,7 @@ func (c *ClientTimerLayer) SendMessageWithAttachments(teamID string, channelID s
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessageWithAttachments", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SendMessageWithAttachments", success, elapsed)
 	return result, err
 }
 
@@ -512,9 +452,7 @@ func (c *ClientTimerLayer) SetChatReaction(chatID string, messageID string, user
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SetChatReaction", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SetChatReaction", success, elapsed)
 	return result, err
 }
 
@@ -528,9 +466,7 @@ func (c *ClientTimerLayer) SetReaction(teamID string, channelID string, parentID
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SetReaction", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SetReaction", success, elapsed)
 	return result, err
 }
 
@@ -544,9 +480,7 @@ func (c *ClientTimerLayer) SubscribeToChannel(teamID string, channelID string, b
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannel", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannel", success, elapsed)
 	return result, err
 }
 
@@ -560,9 +494,7 @@ func (c *ClientTimerLayer) SubscribeToChannels(baseURL string, webhookSecret str
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannels", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChannels", success, elapsed)
 	return result, err
 }
 
@@ -576,9 +508,7 @@ func (c *ClientTimerLayer) SubscribeToChats(baseURL string, webhookSecret string
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChats", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToChats", success, elapsed)
 	return result, err
 }
 
@@ -592,9 +522,7 @@ func (c *ClientTimerLayer) SubscribeToUserChats(user string, baseURL string, web
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToUserChats", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.SubscribeToUserChats", success, elapsed)
 	return result, err
 }
 
@@ -608,9 +536,7 @@ func (c *ClientTimerLayer) UnsetChatReaction(chatID string, messageID string, us
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetChatReaction", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetChatReaction", success, elapsed)
 	return result, err
 }
 
@@ -624,9 +550,7 @@ func (c *ClientTimerLayer) UnsetReaction(teamID string, channelID string, parent
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetReaction", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UnsetReaction", success, elapsed)
 	return result, err
 }
 
@@ -640,9 +564,7 @@ func (c *ClientTimerLayer) UpdateChatMessage(chatID string, msgID string, messag
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateChatMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateChatMessage", success, elapsed)
 	return result, err
 }
 
@@ -656,9 +578,7 @@ func (c *ClientTimerLayer) UpdateMessage(teamID string, channelID string, parent
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateMessage", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UpdateMessage", success, elapsed)
 	return result, err
 }
 
@@ -672,9 +592,7 @@ func (c *ClientTimerLayer) UploadFile(teamID string, channelID string, filename 
 	if err == nil {
 		success = "true"
 	}
-	if c.metrics != nil {
-		c.metrics.ObserveMSGraphClientMethodDuration("Client.UploadFile", success, elapsed)
-	}
+	c.metrics.ObserveMSGraphClientMethodDuration("Client.UploadFile", success, elapsed)
 	return result, err
 }
 

--- a/server/msteams/layer_generators/timer_layer.go.tmpl
+++ b/server/msteams/layer_generators/timer_layer.go.tmpl
@@ -35,9 +35,7 @@ func (c *{{$.Name}}) {{$index}}({{$element.Params | joinParamsWithType}}) {{$ele
         if {{$element.Results | errorToBoolean}} {
                 success = "true"
         }
-		if c.metrics != nil {
-        	c.metrics.ObserveMSGraphClientMethodDuration("Client.{{$index}}", success, elapsed)
-		}
+        c.metrics.ObserveMSGraphClientMethodDuration("Client.{{$index}}", success, elapsed)
 	{{ with (genResultsVars $element.Results false ) -}}
 	return {{ . }}
 	{{- end }}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -431,9 +431,7 @@ func (p *Plugin) syncUsers() {
 		return
 	}
 
-	if p.metricsService != nil {
-		p.metricsService.ObserveUpstreamUsers(int64(len(msUsers)))
-	}
+	p.metricsService.ObserveUpstreamUsers(int64(len(msUsers)))
 	mmUsers, appErr := p.API.GetUsers(&model.UserGetOptions{Page: 0, PerPage: math.MaxInt32})
 	if appErr != nil {
 		p.API.LogError("Unable to get MM users during sync user job", "error", appErr.Error())
@@ -633,11 +631,9 @@ func (p *Plugin) runMetricsUpdaterTask(store store.Store, updateMetricsTaskFrequ
 		if err != nil {
 			p.API.LogError("failed to update computed metrics", "error", err)
 		}
-		if p.metricsService != nil {
-			p.metricsService.ObserveConnectedUsers(stats.ConnectedUsers)
-			p.metricsService.ObserveSyntheticUsers(stats.SyntheticUsers)
-			p.metricsService.ObserveLinkedChannels(stats.LinkedChannels)
-		}
+		p.metricsService.ObserveConnectedUsers(stats.ConnectedUsers)
+		p.metricsService.ObserveSyntheticUsers(stats.SyntheticUsers)
+		p.metricsService.ObserveLinkedChannels(stats.LinkedChannels)
 	}
 
 	metricsUpdater()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -302,6 +302,10 @@ func (p *Plugin) OnActivate() error {
 
 		// run metrics server to expose data
 		p.runMetricsServer()
+	} else {
+		// Give metricsService a concrete, but nil value, making the interface itself
+		// not-nil and safe to use without `metrics != nil` checks everywhere.
+		p.metricsService = metrics.NilMetrics()
 	}
 
 	data, appErr := p.API.KVGet(lastReceivedChangeKey)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -295,17 +295,9 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
-	enableMetrics := p.API.GetConfig().MetricsSettings.Enable
-
-	if enableMetrics != nil && *enableMetrics {
-		p.metricsService = metrics.NewMetrics(metrics.InstanceInfo{
-			InstallationID: os.Getenv("MM_CLOUD_INSTALLATION_ID"),
-		})
-	} else {
-		// Give metricsService a concrete, but nil value, making the interface itself
-		// not-nil and safe to use without `metrics != nil` checks everywhere.
-		p.metricsService = metrics.NilMetrics()
-	}
+	p.metricsService = metrics.NewMetrics(metrics.InstanceInfo{
+		InstallationID: os.Getenv("MM_CLOUD_INSTALLATION_ID"),
+	})
 
 	data, appErr := p.API.KVGet(lastReceivedChangeKey)
 	if appErr != nil {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -138,7 +138,7 @@ func (p *Plugin) GetClientForUser(userID string) (msteams.Client, error) {
 		return nil, errors.New("not connected user")
 	}
 	client := p.clientBuilderWithToken(p.GetURL()+"/oauth-redirect", p.getConfiguration().TenantID, p.getConfiguration().ClientID, p.getConfiguration().ClientSecret, token, &p.apiClient.Log)
-	return client_timerlayer.New(client, p.metricsService), nil
+	return client_timerlayer.New(client, p.GetMetrics()), nil
 }
 
 func (p *Plugin) GetClientForTeamsUser(teamsUserID string) (msteams.Client, error) {
@@ -148,7 +148,7 @@ func (p *Plugin) GetClientForTeamsUser(teamsUserID string) (msteams.Client, erro
 	}
 
 	client := p.clientBuilderWithToken(p.GetURL()+"/oauth-redirect", p.getConfiguration().TenantID, p.getConfiguration().ClientID, p.getConfiguration().ClientSecret, token, &p.apiClient.Log)
-	return client_timerlayer.New(client, p.metricsService), nil
+	return client_timerlayer.New(client, p.GetMetrics()), nil
 }
 
 func (p *Plugin) connectTeamsAppClient() error {
@@ -163,7 +163,7 @@ func (p *Plugin) connectTeamsAppClient() error {
 			&p.apiClient.Log,
 		)
 
-		p.msteamsAppClient = client_timerlayer.New(msteamsAppClient, p.metricsService)
+		p.msteamsAppClient = client_timerlayer.New(msteamsAppClient, p.GetMetrics())
 	}
 	err := p.msteamsAppClient.Connect()
 	if err != nil {
@@ -188,7 +188,7 @@ func (p *Plugin) start(syncSince *time.Time) {
 		return
 	}
 
-	p.monitor = monitor.New(p.msteamsAppClient, p.store, p.API, p.metricsService, p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI)
+	p.monitor = monitor.New(p.msteamsAppClient, p.store, p.API, p.GetMetrics(), p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI)
 	if err = p.monitor.Start(); err != nil {
 		p.API.LogError("Unable to start the monitoring system", "error", err.Error())
 	}
@@ -367,7 +367,7 @@ func (p *Plugin) OnActivate() error {
 			func() []string { return strings.Split(p.configuration.EnabledTeams, ",") },
 			func() []byte { return []byte(p.configuration.EncryptionKey) },
 		)
-		p.store = timerlayer.New(store, p.metricsService)
+		p.store = timerlayer.New(store, p.GetMetrics())
 		if err = p.store.Init(); err != nil {
 			return err
 		}
@@ -431,7 +431,7 @@ func (p *Plugin) syncUsers() {
 		return
 	}
 
-	p.metricsService.ObserveUpstreamUsers(int64(len(msUsers)))
+	p.GetMetrics().ObserveUpstreamUsers(int64(len(msUsers)))
 	mmUsers, appErr := p.API.GetUsers(&model.UserGetOptions{Page: 0, PerPage: math.MaxInt32})
 	if appErr != nil {
 		p.API.LogError("Unable to get MM users during sync user job", "error", appErr.Error())
@@ -614,7 +614,7 @@ func isRemoteUser(user *model.User) bool {
 func (p *Plugin) runMetricsServer() {
 	p.API.LogInfo("Starting metrics server", "port", metricsExposePort)
 
-	p.metricsServer = metrics.NewMetricsServer(metricsExposePort, p.metricsService)
+	p.metricsServer = metrics.NewMetricsServer(metricsExposePort, p.GetMetrics())
 
 	// Run server to expose metrics
 	go func() {
@@ -631,9 +631,9 @@ func (p *Plugin) runMetricsUpdaterTask(store store.Store, updateMetricsTaskFrequ
 		if err != nil {
 			p.API.LogError("failed to update computed metrics", "error", err)
 		}
-		p.metricsService.ObserveConnectedUsers(stats.ConnectedUsers)
-		p.metricsService.ObserveSyntheticUsers(stats.SyntheticUsers)
-		p.metricsService.ObserveLinkedChannels(stats.LinkedChannels)
+		p.GetMetrics().ObserveConnectedUsers(stats.ConnectedUsers)
+		p.GetMetrics().ObserveSyntheticUsers(stats.SyntheticUsers)
+		p.GetMetrics().ObserveLinkedChannels(stats.LinkedChannels)
 	}
 
 	metricsUpdater()

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -50,7 +50,6 @@ func newTestPlugin(t *testing.T) *Plugin {
 		clientBuilderWithToken: func(redirectURL, tenantID, clientId, clientSecret string, token *oauth2.Token, apiClient *pluginapi.LogService) msteams.Client {
 			return clientMock
 		},
-		metricsService: &metricsmocks.Metrics{},
 	}
 	plugin.store.(*storemocks.Store).Test(t)
 
@@ -87,11 +86,13 @@ func newTestPlugin(t *testing.T) *Plugin {
 	plugin.API.(*plugintest.API).On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("/")}}, nil).Times(2)
 	plugin.API.(*plugintest.API).On("GetPluginStatus", pluginID).Return(&model.PluginStatus{PluginId: pluginID, PluginPath: getPluginPathForTest()}, nil)
 	// TODO: Add separate mocks for each test later.
-	plugin.metricsService.(*metricsmocks.Metrics).On("IncrementHTTPRequests")
-	plugin.metricsService.(*metricsmocks.Metrics).On("ObserveAPIEndpointDuration", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("float64"))
+	mockMetricsService := &metricsmocks.Metrics{}
+	mockMetricsService.On("IncrementHTTPRequests")
+	mockMetricsService.On("ObserveAPIEndpointDuration", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("float64"))
 
 	plugin.API.(*plugintest.API).Test(t)
 	_ = plugin.OnActivate()
+	plugin.metricsService = mockMetricsService
 	plugin.userID = "bot-user-id"
 	return plugin
 }

--- a/server/store/layer_generators/timer_layer.go.tmpl
+++ b/server/store/layer_generators/timer_layer.go.tmpl
@@ -35,9 +35,7 @@ func (s *{{$.Name}}) {{$index}}({{$element.Params | joinParamsWithType}}) {{$ele
         if {{$element.Results | errorToBoolean}} {
                 success = "true"
         }
-		if s.metrics != nil {
-			s.metrics.ObserveStoreMethodDuration("Store.{{$index}}", success, elapsed)
-		}
+	s.metrics.ObserveStoreMethodDuration("Store.{{$index}}", success, elapsed)
 	{{ with (genResultsVars $element.Results false ) -}}
 	return {{ . }}
 	{{- else -}}

--- a/server/store/timerlayer/timerlayer.go
+++ b/server/store/timerlayer/timerlayer.go
@@ -32,9 +32,7 @@ func (s *TimerLayer) CheckEnabledTeamByTeamID(teamID string) bool {
 	if true {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.CheckEnabledTeamByTeamID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.CheckEnabledTeamByTeamID", success, elapsed)
 	return result
 }
 
@@ -48,9 +46,7 @@ func (s *TimerLayer) CompareAndSetJobStatus(jobName string, oldStatus bool, newS
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.CompareAndSetJobStatus", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.CompareAndSetJobStatus", success, elapsed)
 	return result, err
 }
 
@@ -64,9 +60,7 @@ func (s *TimerLayer) DeleteDMAndGMChannelPromptTime(userID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.DeleteDMAndGMChannelPromptTime", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.DeleteDMAndGMChannelPromptTime", success, elapsed)
 	return err
 }
 
@@ -80,9 +74,7 @@ func (s *TimerLayer) DeleteLinkByChannelID(channelID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.DeleteLinkByChannelID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.DeleteLinkByChannelID", success, elapsed)
 	return err
 }
 
@@ -96,9 +88,7 @@ func (s *TimerLayer) DeleteSubscription(subscriptionID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.DeleteSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.DeleteSubscription", success, elapsed)
 	return err
 }
 
@@ -112,9 +102,7 @@ func (s *TimerLayer) DeleteUserInfo(mmUserID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.DeleteUserInfo", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.DeleteUserInfo", success, elapsed)
 	return err
 }
 
@@ -128,9 +116,7 @@ func (s *TimerLayer) GetAvatarCache(userID string) ([]byte, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetAvatarCache", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetAvatarCache", success, elapsed)
 	return result, err
 }
 
@@ -144,9 +130,7 @@ func (s *TimerLayer) GetChannelSubscription(subscriptionID string) (*storemodels
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetChannelSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetChannelSubscription", success, elapsed)
 	return result, err
 }
 
@@ -160,9 +144,7 @@ func (s *TimerLayer) GetChannelSubscriptionByTeamsChannelID(teamsChannelID strin
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetChannelSubscriptionByTeamsChannelID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetChannelSubscriptionByTeamsChannelID", success, elapsed)
 	return result, err
 }
 
@@ -176,9 +158,7 @@ func (s *TimerLayer) GetChatSubscription(subscriptionID string) (*storemodels.Ch
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetChatSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetChatSubscription", success, elapsed)
 	return result, err
 }
 
@@ -192,9 +172,7 @@ func (s *TimerLayer) GetConnectedUsers(page int, perPage int) ([]*storemodels.Co
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetConnectedUsers", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetConnectedUsers", success, elapsed)
 	return result, err
 }
 
@@ -208,9 +186,7 @@ func (s *TimerLayer) GetDMAndGMChannelPromptTime(channelID string, userID string
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetDMAndGMChannelPromptTime", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetDMAndGMChannelPromptTime", success, elapsed)
 	return result, err
 }
 
@@ -224,9 +200,7 @@ func (s *TimerLayer) GetGlobalSubscription(subscriptionID string) (*storemodels.
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetGlobalSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetGlobalSubscription", success, elapsed)
 	return result, err
 }
 
@@ -240,9 +214,7 @@ func (s *TimerLayer) GetLinkByChannelID(channelID string) (*storemodels.ChannelL
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetLinkByChannelID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetLinkByChannelID", success, elapsed)
 	return result, err
 }
 
@@ -256,9 +228,7 @@ func (s *TimerLayer) GetLinkByMSTeamsChannelID(teamID string, channelID string) 
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetLinkByMSTeamsChannelID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetLinkByMSTeamsChannelID", success, elapsed)
 	return result, err
 }
 
@@ -272,9 +242,7 @@ func (s *TimerLayer) GetPostInfoByMSTeamsID(chatID string, postID string) (*stor
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetPostInfoByMSTeamsID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetPostInfoByMSTeamsID", success, elapsed)
 	return result, err
 }
 
@@ -288,9 +256,7 @@ func (s *TimerLayer) GetPostInfoByMattermostID(postID string) (*storemodels.Post
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetPostInfoByMattermostID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetPostInfoByMattermostID", success, elapsed)
 	return result, err
 }
 
@@ -304,9 +270,7 @@ func (s *TimerLayer) GetSizeOfWhitelist() (int, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetSizeOfWhitelist", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetSizeOfWhitelist", success, elapsed)
 	return result, err
 }
 
@@ -320,9 +284,7 @@ func (s *TimerLayer) GetStats() (*storemodels.Stats, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetStats", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetStats", success, elapsed)
 	return result, err
 }
 
@@ -336,9 +298,7 @@ func (s *TimerLayer) GetSubscriptionType(subscriptionID string) (string, error) 
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetSubscriptionType", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetSubscriptionType", success, elapsed)
 	return result, err
 }
 
@@ -352,9 +312,7 @@ func (s *TimerLayer) GetTokenForMSTeamsUser(userID string) (*oauth2.Token, error
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetTokenForMSTeamsUser", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetTokenForMSTeamsUser", success, elapsed)
 	return result, err
 }
 
@@ -368,9 +326,7 @@ func (s *TimerLayer) GetTokenForMattermostUser(userID string) (*oauth2.Token, er
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.GetTokenForMattermostUser", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.GetTokenForMattermostUser", success, elapsed)
 	return result, err
 }
 
@@ -384,9 +340,7 @@ func (s *TimerLayer) Init() error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.Init", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.Init", success, elapsed)
 	return err
 }
 
@@ -400,9 +354,7 @@ func (s *TimerLayer) IsUserPresentInWhitelist(userID string) (bool, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.IsUserPresentInWhitelist", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.IsUserPresentInWhitelist", success, elapsed)
 	return result, err
 }
 
@@ -416,9 +368,7 @@ func (s *TimerLayer) LinkPosts(tx *sql.Tx, postInfo storemodels.PostInfo) error 
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.LinkPosts", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.LinkPosts", success, elapsed)
 	return err
 }
 
@@ -432,9 +382,7 @@ func (s *TimerLayer) ListChannelLinks() ([]storemodels.ChannelLink, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListChannelLinks", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListChannelLinks", success, elapsed)
 	return result, err
 }
 
@@ -448,9 +396,7 @@ func (s *TimerLayer) ListChannelLinksWithNames() ([]*storemodels.ChannelLink, er
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListChannelLinksWithNames", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListChannelLinksWithNames", success, elapsed)
 	return result, err
 }
 
@@ -464,9 +410,7 @@ func (s *TimerLayer) ListChannelSubscriptions() ([]*storemodels.ChannelSubscript
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListChannelSubscriptions", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListChannelSubscriptions", success, elapsed)
 	return result, err
 }
 
@@ -480,9 +424,7 @@ func (s *TimerLayer) ListChannelSubscriptionsToRefresh() ([]*storemodels.Channel
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListChannelSubscriptionsToRefresh", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListChannelSubscriptionsToRefresh", success, elapsed)
 	return result, err
 }
 
@@ -496,9 +438,7 @@ func (s *TimerLayer) ListChatSubscriptionsToCheck() ([]storemodels.ChatSubscript
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListChatSubscriptionsToCheck", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListChatSubscriptionsToCheck", success, elapsed)
 	return result, err
 }
 
@@ -512,9 +452,7 @@ func (s *TimerLayer) ListGlobalSubscriptions() ([]*storemodels.GlobalSubscriptio
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListGlobalSubscriptions", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListGlobalSubscriptions", success, elapsed)
 	return result, err
 }
 
@@ -528,9 +466,7 @@ func (s *TimerLayer) ListGlobalSubscriptionsToRefresh() ([]*storemodels.GlobalSu
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.ListGlobalSubscriptionsToRefresh", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.ListGlobalSubscriptionsToRefresh", success, elapsed)
 	return result, err
 }
 
@@ -544,9 +480,7 @@ func (s *TimerLayer) LockPostByMMPostID(tx *sql.Tx, messageID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.LockPostByMMPostID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.LockPostByMMPostID", success, elapsed)
 	return err
 }
 
@@ -560,9 +494,7 @@ func (s *TimerLayer) LockPostByMSTeamsPostID(tx *sql.Tx, messageID string) error
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.LockPostByMSTeamsPostID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.LockPostByMSTeamsPostID", success, elapsed)
 	return err
 }
 
@@ -576,9 +508,7 @@ func (s *TimerLayer) MattermostToTeamsUserID(userID string) (string, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.MattermostToTeamsUserID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.MattermostToTeamsUserID", success, elapsed)
 	return result, err
 }
 
@@ -592,9 +522,7 @@ func (s *TimerLayer) PrefillWhitelist() error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.PrefillWhitelist", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.PrefillWhitelist", success, elapsed)
 	return err
 }
 
@@ -608,9 +536,7 @@ func (s *TimerLayer) RecoverPost(postID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.RecoverPost", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.RecoverPost", success, elapsed)
 	return err
 }
 
@@ -624,9 +550,7 @@ func (s *TimerLayer) SaveChannelSubscription(tx *sql.Tx, subscription storemodel
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SaveChannelSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SaveChannelSubscription", success, elapsed)
 	return err
 }
 
@@ -640,9 +564,7 @@ func (s *TimerLayer) SaveChatSubscription(subscription storemodels.ChatSubscript
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SaveChatSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SaveChatSubscription", success, elapsed)
 	return err
 }
 
@@ -656,9 +578,7 @@ func (s *TimerLayer) SaveGlobalSubscription(subscription storemodels.GlobalSubsc
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SaveGlobalSubscription", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SaveGlobalSubscription", success, elapsed)
 	return err
 }
 
@@ -672,9 +592,7 @@ func (s *TimerLayer) SetAvatarCache(userID string, photo []byte) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SetAvatarCache", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SetAvatarCache", success, elapsed)
 	return err
 }
 
@@ -688,9 +606,7 @@ func (s *TimerLayer) SetJobStatus(jobName string, status bool) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SetJobStatus", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SetJobStatus", success, elapsed)
 	return err
 }
 
@@ -704,9 +620,7 @@ func (s *TimerLayer) SetPostLastUpdateAtByMSTeamsID(tx *sql.Tx, postID string, l
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SetPostLastUpdateAtByMSTeamsID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SetPostLastUpdateAtByMSTeamsID", success, elapsed)
 	return err
 }
 
@@ -720,9 +634,7 @@ func (s *TimerLayer) SetPostLastUpdateAtByMattermostID(tx *sql.Tx, postID string
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SetPostLastUpdateAtByMattermostID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SetPostLastUpdateAtByMattermostID", success, elapsed)
 	return err
 }
 
@@ -736,9 +648,7 @@ func (s *TimerLayer) SetUserInfo(userID string, msTeamsUserID string, token *oau
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.SetUserInfo", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.SetUserInfo", success, elapsed)
 	return err
 }
 
@@ -752,9 +662,7 @@ func (s *TimerLayer) StoreChannelLink(link *storemodels.ChannelLink) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.StoreChannelLink", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.StoreChannelLink", success, elapsed)
 	return err
 }
 
@@ -768,9 +676,7 @@ func (s *TimerLayer) StoreDMAndGMChannelPromptTime(channelID string, userID stri
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.StoreDMAndGMChannelPromptTime", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.StoreDMAndGMChannelPromptTime", success, elapsed)
 	return err
 }
 
@@ -784,9 +690,7 @@ func (s *TimerLayer) StoreOAuth2State(state string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.StoreOAuth2State", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.StoreOAuth2State", success, elapsed)
 	return err
 }
 
@@ -800,9 +704,7 @@ func (s *TimerLayer) StoreUserInWhitelist(userID string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.StoreUserInWhitelist", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.StoreUserInWhitelist", success, elapsed)
 	return err
 }
 
@@ -816,9 +718,7 @@ func (s *TimerLayer) TeamsToMattermostUserID(userID string) (string, error) {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.TeamsToMattermostUserID", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.TeamsToMattermostUserID", success, elapsed)
 	return result, err
 }
 
@@ -832,9 +732,7 @@ func (s *TimerLayer) UpdateSubscriptionExpiresOn(subscriptionID string, expiresO
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.UpdateSubscriptionExpiresOn", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.UpdateSubscriptionExpiresOn", success, elapsed)
 	return err
 }
 
@@ -848,9 +746,7 @@ func (s *TimerLayer) VerifyOAuth2State(state string) error {
 	if err == nil {
 		success = "true"
 	}
-	if s.metrics != nil {
-		s.metrics.ObserveStoreMethodDuration("Store.VerifyOAuth2State", success, elapsed)
-	}
+	s.metrics.ObserveStoreMethodDuration("Store.VerifyOAuth2State", success, elapsed)
 	return err
 }
 


### PR DESCRIPTION
#### Summary
With the change to passing around an interface instead of a concrete type, it was necessary to check `metrics != nil`. Improve this by always setting `metrics` to a concrete value, even if the underlying value is `nil`. This allows all calling code to safely use `metrics` without a `nil` check.

#### Ticket Link
None.