### PR TITLE
add discardedReason to lifecycle event metrics

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/store"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/store/storemodels"
@@ -147,13 +148,18 @@ func (a *API) processLifecycle(w http.ResponseWriter, req *http.Request) {
 
 	a.p.API.LogDebug("Lifecycle activity request", "activities", lifecycleEvents)
 
+	errors := ""
 	for _, event := range lifecycleEvents.Value {
 		if event.ClientState != a.p.getConfiguration().WebhookSecret {
-			a.p.API.LogError("Invalid webhook secret received in lifecycle event")
+			a.p.metricsService.ObserveLifecycleEvent(event.LifecycleEvent, metrics.DiscardedReasonInvalidWebhookSecret)
+			errors += "Invalid webhook secret"
 			continue
 		}
-		a.p.GetMetrics().ObserveLifecycleEvent(event.LifecycleEvent)
 		a.p.activityHandler.HandleLifecycleEvent(event)
+	}
+	if errors != "" {
+		http.Error(w, errors, http.StatusBadRequest)
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -388,11 +388,13 @@ func TestProcessLifecycle(t *testing.T) {
 		ExpectedResult     string
 	}{
 		{
-			Name:            "ProcessLifecycle: With validation token present",
-			SetupAPI:        func(api *plugintest.API) {},
-			SetupClient:     func(client *clientmocks.Client, uclient *clientmocks.Client) {},
-			SetupStore:      func(store *storemocks.Store) {},
-			SetupMetrics:    func(mockmetrics *metricsmocks.Metrics) {},
+			Name:        "ProcessLifecycle: With validation token present",
+			SetupAPI:    func(api *plugintest.API) {},
+			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {},
+			SetupStore:  func(store *storemocks.Store) {},
+			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
+				mockmetrics.On("ObserveLifecycleEvent", "mockLifecycleEvent", "").Times(1)
+			},
 			ValidationToken: "mockValidationToken",
 			RequestBody: `{
 				"Value": [{
@@ -405,11 +407,13 @@ func TestProcessLifecycle(t *testing.T) {
 			ExpectedResult:     "mockValidationToken",
 		},
 		{
-			Name:               "ProcessLifecycle: Invalid body",
-			SetupAPI:           func(api *plugintest.API) {},
-			SetupClient:        func(client *clientmocks.Client, uclient *clientmocks.Client) {},
-			SetupStore:         func(store *storemocks.Store) {},
-			SetupMetrics:       func(mockmetrics *metricsmocks.Metrics) {},
+			Name:        "ProcessLifecycle: Invalid body",
+			SetupAPI:    func(api *plugintest.API) {},
+			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {},
+			SetupStore:  func(store *storemocks.Store) {},
+			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
+				mockmetrics.On("IncrementHTTPErrors").Times(1)
+			},
 			RequestBody:        `{`,
 			ExpectedStatusCode: http.StatusBadRequest,
 			ExpectedResult:     "unable to get the lifecycle events from the message\n",
@@ -419,9 +423,12 @@ func TestProcessLifecycle(t *testing.T) {
 			SetupAPI: func(api *plugintest.API) {
 				api.On("LogError", "Invalid webhook secret received in lifecycle event").Times(1)
 			},
-			SetupClient:  func(client *clientmocks.Client, uclient *clientmocks.Client) {},
-			SetupStore:   func(store *storemocks.Store) {},
-			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {},
+			SetupClient: func(client *clientmocks.Client, uclient *clientmocks.Client) {},
+			SetupStore:  func(store *storemocks.Store) {},
+			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
+				mockmetrics.On("IncrementHTTPErrors").Times(1)
+				mockmetrics.On("ObserveLifecycleEvent", "mockLifecycleEvent", mock.AnythingOfType("string")).Times(1)
+			},
 
 			RequestBody: `{
 				"Value": [{
@@ -430,7 +437,8 @@ func TestProcessLifecycle(t *testing.T) {
 				"ChangeType": "mockChangeType",
 				"LifecycleEvent": "mockLifecycleEvent"
 			}]}`,
-			ExpectedStatusCode: http.StatusOK,
+			ExpectedStatusCode: http.StatusBadRequest,
+			ExpectedResult:     "Invalid webhook secret\n",
 		},
 		{
 			Name:        "ProcessLifecycle: Valid body with valid webhook secret and without refresh needed",
@@ -443,7 +451,9 @@ func TestProcessLifecycle(t *testing.T) {
 				}, nil).Once()
 				store.On("GetLinkByMSTeamsChannelID", testutils.GetTeamsTeamID(), testutils.GetMSTeamsChannelID()).Return(nil, nil).Once()
 			},
-			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {},
+			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
+				mockmetrics.On("ObserveLifecycleEvent", "mockLifecycleEvent", "").Times(1)
+			},
 			RequestBody: `{
 				"Value": [{
 				"SubscriptionID": "mockID",
@@ -470,6 +480,7 @@ func TestProcessLifecycle(t *testing.T) {
 			},
 			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {
 				mockmetrics.On("ObserveSubscription", metrics.SubscriptionRefreshed).Times(1)
+				mockmetrics.On("ObserveLifecycleEvent", "reauthorizationRequired", "").Times(1)
 			},
 			RequestBody: `{
 				"Value": [{
@@ -484,13 +495,6 @@ func TestProcessLifecycle(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			assert := assert.New(t)
 			plugin := newTestPlugin(t)
-			if test.ExpectedResult != "" {
-				plugin.metricsService.(*metricsmocks.Metrics).On("IncrementHTTPErrors").Times(1)
-			}
-
-			if test.ExpectedStatusCode == http.StatusOK {
-				plugin.metricsService.(*metricsmocks.Metrics).On("ObserveLifecycleEvent", mock.AnythingOfType("string")).Times(1)
-			}
 
 			test.SetupStore(plugin.store.(*storemocks.Store))
 			test.SetupAPI(plugin.API.(*plugintest.API))

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -60,7 +60,7 @@ type Metrics interface {
 	ObserveChangeEventQueueRejected()
 
 	ObserveChangeEvent(changeType string, discardedReason string)
-	ObserveLifecycleEvent(lifecycleEventType string)
+	ObserveLifecycleEvent(lifecycleEventType, discardedReason string)
 	ObserveMessage(action, source string, isDirectMessage bool)
 	ObserveReaction(action, source string, isDirectMessage bool)
 	ObserveFiles(action, source, discardedReason string, isDirectMessage bool, count int64)
@@ -348,9 +348,9 @@ func (m *metrics) ObserveChangeEvent(changeType string, discardedReason string) 
 	}
 }
 
-func (m *metrics) ObserveLifecycleEvent(lifecycleEventType string) {
+func (m *metrics) ObserveLifecycleEvent(eventType string, discardedReason string) {
 	if m != nil {
-		m.lifecycleEventsTotal.With(prometheus.Labels{"event_type": lifecycleEventType}).Inc()
+		m.lifecycleEventsTotal.With(prometheus.Labels{"event_type": eventType, "discarded_reason": discardedReason}).Inc()
 	}
 }
 

--- a/server/metrics/mocks/Metrics.go
+++ b/server/metrics/mocks/Metrics.go
@@ -88,9 +88,9 @@ func (_m *Metrics) ObserveFiles(action string, source string, discardedReason st
 	_m.Called(action, source, discardedReason, isDirectMessage, count)
 }
 
-// ObserveLifecycleEvent provides a mock function with given fields: lifecycleEventType
-func (_m *Metrics) ObserveLifecycleEvent(lifecycleEventType string) {
-	_m.Called(lifecycleEventType)
+// ObserveLifecycleEvent provides a mock function with given fields: eventType, discardedReason
+func (_m *Metrics) ObserveLifecycleEvent(eventType string, discardedReason string) {
+	_m.Called(eventType, discardedReason)
 }
 
 // ObserveLinkedChannels provides a mock function with given fields: count


### PR DESCRIPTION
#### Summary
Add `discardedReason` to lifecycle event metrics and improving error handling when an invalid webhook secret occurs.

#### Ticket Link
None.