### PR TITLE
delay metrics server start

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "min_server_version": "7.8.10",
     "server": {
         "executables": {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -177,6 +177,8 @@ func (p *Plugin) start(syncSince *time.Time) {
 	enableMetrics := p.API.GetConfig().MetricsSettings.Enable
 
 	if enableMetrics != nil && *enableMetrics {
+		// run metrics server to expose data
+		p.runMetricsServer()
 		// run metrics updater recurring task
 		p.runMetricsUpdaterTask(p.store, updateMetricsTaskFrequency)
 	}
@@ -299,9 +301,6 @@ func (p *Plugin) OnActivate() error {
 		p.metricsService = metrics.NewMetrics(metrics.InstanceInfo{
 			InstallationID: os.Getenv("MM_CLOUD_INSTALLATION_ID"),
 		})
-
-		// run metrics server to expose data
-		p.runMetricsServer()
 	}
 
 	data, appErr := p.API.KVGet(lastReceivedChangeKey)


### PR DESCRIPTION
#### Summary
As part of e82ec25fc832b95b16d53d856911ac24ed088e13, I created the metrics service earlier to make it available to the DB Store initialization that occurs in `OnActivate()`. At the time, I took along the code to actually run the metrics server exposed on `:9094`, but for reasons yet unknown, exposing the port during `OnActivate` early in a k8s pod's life cycle makes it unreachable.

Delaying the server start until after `OnActivate` returns -- where it was in v1.2 -- resolves the issue. More investigation is required to understand the root cause, but this should resolve the metric scraping issues.

#### Ticket Link
None.