### PR TITLE
[MI-3714] Integrated the Link channels modal with the APIs

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -53,9 +53,7 @@ func (p *Plugin) sendBotEphemeralPost(userID, channelID, message string) {
 func getAutocompleteData() *model.AutocompleteData {
 	cmd := model.NewAutocompleteData(msteamsCommand, "[command]", "Manage MS Teams linked channels")
 
-	link := model.NewAutocompleteData("link", "[msteams-team-id] [msteams-channel-id]", "Link current channel to a MS Teams channel")
-	link.AddDynamicListArgument("[msteams-team-id]", getAutocompletePath("teams"), true)
-	link.AddDynamicListArgument("[msteams-channel-id]", getAutocompletePath("channels"), true)
+	link := model.NewAutocompleteData("link", "", "Link current channel to a MS Teams channel")
 	cmd.AddCommand(link)
 
 	unlink := model.NewAutocompleteData("unlink", "", "Unlink the current channel from the MS Teams channel")
@@ -166,11 +164,6 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 	}
 
 	link, err := p.store.GetLinkByChannelID(args.ChannelId)
-	if err == nil && link != nil {
-		return p.cmdError(args.UserId, args.ChannelId, "A link for this channel already exists. Please unlink the channel before you link again with another channel.")
-	}
-
-	link, err = p.store.GetLinkByMSTeamsChannelID(parameters[0], parameters[1])
 	if err == nil && link != nil {
 		return p.cmdError(args.UserId, args.ChannelId, "A link for this channel already exists. Please unlink the channel before you link again with another channel.")
 	}

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -81,10 +81,10 @@ type Subscription struct {
 }
 
 type Channel struct {
-	ID          string
-	DisplayName string
-	Description string
-	Type        models.ChannelMembershipType
+	ID          string                       `json:"id"`
+	DisplayName string                       `json:"display_name"`
+	Description string                       `json:"description"`
+	Type        models.ChannelMembershipType `json:"type"`
 }
 
 type Chat struct {
@@ -108,9 +108,9 @@ type ChatMember struct {
 }
 
 type Team struct {
-	ID          string
-	DisplayName string
-	Description string
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
 }
 
 type Attachment struct {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -51,8 +51,9 @@
     "webpack": "5.76.1",
     "webpack-cli": "5.0.1"
   },
+  "//": ["TODO: Update MM UI lib version after creating a release for it"],
   "dependencies": {
-    "@brightscout/mattermost-ui-library": "2.0.9",
+    "@brightscout/mattermost-ui-library": "file:../../mm-ui-library",
     "@reduxjs/toolkit": "1.8.2",
     "core-js": "3.29.1",
     "js-cookie": "3.0.1",

--- a/webapp/src/constants/apiService.ts
+++ b/webapp/src/constants/apiService.ts
@@ -25,4 +25,19 @@ export const pluginApiServiceConfigs: Record<PluginApiServiceName, PluginApiServ
         method: 'DELETE',
         apiServiceName: 'unlinkChannel',
     },
+    searchMSTeams: {
+        path: '/msteams/teams',
+        method: 'GET',
+        apiServiceName: 'searchMSTeams'
+    },
+    searchMSChannels: {
+        path: '/msteams/teams/{team_id}/channels',
+        method: 'GET',
+        apiServiceName: 'searchMSChannels'
+    },
+    linkChannels: {
+        path: '/link-channels',
+        method: 'POST',
+        apiServiceName: 'linkChannels'
+    },
 };

--- a/webapp/src/containers/Rhs/index.tsx
+++ b/webapp/src/containers/Rhs/index.tsx
@@ -66,7 +66,7 @@ const Rhs = (): JSX.Element => {
     };
 
     useEffect(() => {
-        const linkedChannelsParams: SearchLinkedChannelParams = {search: searchLinkedChannelsText, page: paginationQueryParams.page, per_page: paginationQueryParams.per_page};
+        const linkedChannelsParams: SearchParams = {search: searchLinkedChannelsText, page: paginationQueryParams.page, per_page: paginationQueryParams.per_page};
         setGetLinkedChannelsParams(linkedChannelsParams);
         makeApiRequestWithCompletionStatus(Constants.pluginApiServiceConfigs.getLinkedChannels.apiServiceName, linkedChannelsParams);
     }, [paginationQueryParams]);

--- a/webapp/src/containers/linkChannels/subComponents/mattermostChannelPanel.tsx
+++ b/webapp/src/containers/linkChannels/subComponents/mattermostChannelPanel.tsx
@@ -1,31 +1,75 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import {Client4} from 'mattermost-redux/client';
 
 import {MMSearch, ListItemType} from '@brightscout/mattermost-ui-library';
+import {Channel} from 'src/containers/linkChannels/subComponents';
+import Utils from 'src/utils';
+import Constants from 'src/constants';
 
 export type ChannelPanelProps = {
     className?: string;
-    channelOptions: DropdownOptionType[],
-    setChannel: (value: string | null) => void;
+    setChannel: (value: Channel | null) => void;
     placeholder: string;
-    optionsLoading?: boolean;
+    teamId: string | null,
 }
 
 const MattermostChannelPanel = ({
     className = '',
-    channelOptions,
     setChannel,
     placeholder,
-    optionsLoading = false,
+    teamId,
 }: ChannelPanelProps): JSX.Element => {
     const [searchTerm, setSearchTerm] = useState<string>('');
+    const [searchSuggestions, setSearchSuggestions] = useState<DropdownOptionType[]>([]);
+    const [suggestionsLoading, setSuggestionsLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        handleClearInput();
+    }, [teamId])
+
+    const searchChannels = ({searchFor}: {searchFor?: string}) => {
+        if(searchFor && teamId) {
+            setSuggestionsLoading(true);
+            Client4.autocompleteChannelsForSearch(teamId, searchFor)
+            .then((channels) => {
+                const suggestions = [];
+                for(const channel of channels) {
+                    suggestions.push({
+                        label: channel.display_name,
+                        value: channel.id,
+                    })
+                }
+                setSearchSuggestions(suggestions);
+                setSuggestionsLoading(false);
+            }).catch((err) => {
+                // TODO: Handle error here
+                setSuggestionsLoading(false);
+            })
+        }
+    }
+
+    const debouncedSearchChannels = useCallback(Utils.debounce(searchChannels, Constants.DebounceFunctionTimeLimit), [searchChannels]);
+
+    const handleSearch = (val: string) => {
+        if(!val) {
+            setSearchSuggestions([]);
+        }
+        setSearchTerm(val);
+        debouncedSearchChannels({searchFor: val})
+    }
 
     const handleChannelSelect = (_: any, option: ListItemType) => {
-        setChannel(option.value);
-        setSearchTerm(option.value);
+        setChannel({
+            id: option.value,
+            displayName: option.label as string,
+        });
+        setSearchTerm(option.label as string);
     };
 
     const handleClearInput = () => {
         setSearchTerm('');
+        setSearchSuggestions([]);
         setChannel(null);
     }
 
@@ -36,12 +80,12 @@ const MattermostChannelPanel = ({
                 autoFocus={true}
                 fullWidth={true}
                 className={className}
-                items={channelOptions}
+                items={searchSuggestions}
                 onSelect={handleChannelSelect}
                 searchValue={searchTerm}
-                setSearchValue={setSearchTerm}
-                optionsLoading={optionsLoading}
+                setSearchValue={handleSearch}
                 onClearInput={handleClearInput}
+                optionsLoading={suggestionsLoading}
             />
         </div>
     );

--- a/webapp/src/containers/linkChannels/subComponents/mattermostTeamPanel.tsx
+++ b/webapp/src/containers/linkChannels/subComponents/mattermostTeamPanel.tsx
@@ -1,27 +1,48 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
+
+import {Client4} from 'mattermost-redux/client';
 
 import {ListItemType, MMSearch} from '@brightscout/mattermost-ui-library';
+import {Team} from 'src/containers/linkChannels/subComponents';
 
 export type TeamPanelProps = {
     className?: string;
-    teamOptions: DropdownOptionType[],
-    setTeam: (value: string | null) => void;
+    setTeam: (value: Team | null) => void;
     placeholder: string;
-    optionsLoading?: boolean;
 }
 
 const MattermostTeamPanel = ({
     className = '',
-    teamOptions,
-    optionsLoading = false,
     setTeam,
     placeholder,
 }: TeamPanelProps): JSX.Element => {
     const [searchTerm, setSearchTerm] = useState<string>('');
+    const [searchSuggestions, setSearchSuggestions] = useState<DropdownOptionType[]>([]);
+    const [isSearchDisabled, setIsSearchDisabled] = useState<boolean>(true);
+
+    useEffect(() => {
+        Client4.getMyTeams().then((teams) => {
+            const suggestions = [];
+            for(const team of teams) {
+                suggestions.push({
+                    label: team.display_name,
+                    value: team.id,
+                })
+            }
+            setSearchSuggestions(suggestions);
+            setIsSearchDisabled(false);
+        }).catch((err) => {
+            // TODO: Handle error here
+            setIsSearchDisabled(false);
+        })
+    }, [])
 
     const handleTeamSelect = (_: any, option: ListItemType) => {
-        setTeam(option.value);
-        setSearchTerm(option.value);
+        setTeam({
+            id: option.value,
+            displayName: option.label as string,
+        });
+        setSearchTerm(option.label as string);
     };
 
     const handleClearInput = () => {
@@ -32,15 +53,15 @@ const MattermostTeamPanel = ({
     return (
         <div className={className}>
             <MMSearch
+                disabled={isSearchDisabled}
                 label={placeholder}
                 autoFocus={true}
                 fullWidth={true}
                 className={className}
-                items={teamOptions}
+                items={searchSuggestions}
                 onSelect={handleTeamSelect}
                 searchValue={searchTerm}
                 setSearchValue={setSearchTerm}
-                optionsLoading={optionsLoading}
                 onClearInput={handleClearInput}
             />
         </div>

--- a/webapp/src/containers/linkChannels/subComponents/microsoftChannelPanel.tsx
+++ b/webapp/src/containers/linkChannels/subComponents/microsoftChannelPanel.tsx
@@ -1,27 +1,85 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import {MMSearch, ListItemType} from '@brightscout/mattermost-ui-library';
 
 import {ChannelPanelProps} from './mattermostChannelPanel';
+import Utils from 'src/utils';
+import Constants from 'src/constants';
+import useApiRequestCompletionState from 'src/hooks/useApiRequestCompletionState';
+import usePluginApi from 'src/hooks/usePluginApi';
 
 const MicrosoftChannelPanel = ({
     className = '',
-    channelOptions,
     setChannel,
     placeholder,
-    optionsLoading = false,
+    teamId,
 }: ChannelPanelProps): JSX.Element => {
+    const {makeApiRequestWithCompletionStatus, getApiState} = usePluginApi();
     const [searchTerm, setSearchTerm] = useState<string>('');
+    const [searchChannelsPayload, setSearchChannelsPayload] = useState<SearchMSChannelsParams | null>(null);
+    const [searchSuggestions, setSearchSuggestions] = useState<DropdownOptionType[]>([]);
+
+    useEffect(() => {
+        handleClearInput();
+    }, [teamId])
+
+    const searchChannels = ({searchFor}: {searchFor?: string}) => {
+        if(searchFor && teamId) {
+            const payload = {
+                search: searchFor,
+                page: Constants.DefaultPage,
+                per_page: Constants.DefaultPerPage,
+                teamId,
+            }
+            setSearchChannelsPayload(payload);
+            makeApiRequestWithCompletionStatus(Constants.pluginApiServiceConfigs.searchMSChannels.apiServiceName, payload);
+        }
+    }
+
+    const debouncedSearchChannels = useCallback(Utils.debounce(searchChannels, Constants.DebounceFunctionTimeLimit), [searchChannels]);
+
+    const handleSearch = (val: string) => {
+        if(!val) {
+            setSearchSuggestions([]);
+        }
+        setSearchTerm(val);
+        debouncedSearchChannels({searchFor: val})
+    }
 
     const handleChannelSelect = (_: any, option: ListItemType) => {
-        setChannel(option.value);
-        setSearchTerm(option.value);
+        setChannel({
+            id: option.value,
+            displayName: option.label as string,
+        });
+        setSearchTerm(option.label as string);
     };
 
     const handleClearInput = () => {
         setSearchTerm('');
         setChannel(null);
+        setSearchSuggestions([]);
     }
+
+    const {data: searchedChannels, isLoading: searchSuggestionsLoading} = getApiState(Constants.pluginApiServiceConfigs.searchMSChannels.apiServiceName, searchChannelsPayload as SearchMSChannelsParams);
+    useApiRequestCompletionState({
+        serviceName: Constants.pluginApiServiceConfigs.searchMSChannels.apiServiceName,
+        payload: searchChannelsPayload as SearchMSChannelsParams,
+        handleSuccess: () => {
+            if(searchedChannels) {
+                const suggestions: DropdownOptionType[] = [];
+                for(const channel of searchedChannels as MSTeamsSearchResponse) {
+                    suggestions.push({
+                        label: channel.display_name,
+                        value: channel.id,
+                    })
+                }
+                setSearchSuggestions(suggestions);
+            }
+        },
+        handleError: (error) => {
+            // TODO: Handle this error
+        }
+    });
 
     return (
         <div className={className}>
@@ -30,12 +88,12 @@ const MicrosoftChannelPanel = ({
                 autoFocus={true}
                 fullWidth={true}
                 className={className}
-                items={channelOptions}
+                items={searchSuggestions}
                 onSelect={handleChannelSelect}
                 searchValue={searchTerm}
-                setSearchValue={setSearchTerm}
-                optionsLoading={optionsLoading}
+                setSearchValue={handleSearch}
                 onClearInput={handleClearInput}
+                optionsLoading={searchSuggestionsLoading}
             />
         </div>
     );

--- a/webapp/src/containers/linkChannels/subComponents/microsoftTeamPanel.tsx
+++ b/webapp/src/containers/linkChannels/subComponents/microsoftTeamPanel.tsx
@@ -1,27 +1,79 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import {MMSearch, ListItemType} from '@brightscout/mattermost-ui-library';
 
 import {TeamPanelProps} from './mattermostTeamPanel';
+import Utils from 'src/utils';
+import Constants from 'src/constants';
+import useApiRequestCompletionState from 'src/hooks/useApiRequestCompletionState';
+import usePluginApi from 'src/hooks/usePluginApi';
 
 const MicrosoftTeamPanel = ({
     className = '',
-    teamOptions,
-    optionsLoading = false,
     setTeam,
     placeholder,
 }: TeamPanelProps): JSX.Element => {
+    const {makeApiRequestWithCompletionStatus, getApiState} = usePluginApi();
     const [searchTerm, setSearchTerm] = useState<string>('');
+    const [searchTeamsPayload, setSearchTeamsPayload] = useState<SearchParams | null>(null);
+    const [searchSuggestions, setSearchSuggestions] = useState<DropdownOptionType[]>([]);
+
+    const searchTeams = ({searchFor}: {searchFor?: string}) => {
+        if(searchFor) {
+            const payload = {
+                search: searchFor,
+                page: Constants.DefaultPage,
+                per_page: Constants.DefaultPerPage,
+            }
+            setSearchTeamsPayload(payload);
+            makeApiRequestWithCompletionStatus(Constants.pluginApiServiceConfigs.searchMSTeams.apiServiceName, payload);
+        }
+    }
+
+    const debouncedSearchTeams = useCallback(Utils.debounce(searchTeams, Constants.DebounceFunctionTimeLimit), [searchTeams]);
+
+    const handleSearch = (val: string) => {
+        if(!val) {
+            setSearchSuggestions([]);
+        }
+        setSearchTerm(val);
+        debouncedSearchTeams({searchFor: val})
+    }
 
     const handleTeamSelect = (_: any, option: ListItemType) => {
-        setTeam(option.value);
-        setSearchTerm(option.value);
+        setTeam({
+            id: option.value,
+            displayName: option.label as string,
+        });
+        setSearchTerm(option.label as string);
     };
 
     const handleClearInput = () => {
         setSearchTerm('');
         setTeam(null);
+        setSearchSuggestions([]);
     }
+
+    const {data: searchedTeams, isLoading: searchSuggestionsLoading} = getApiState(Constants.pluginApiServiceConfigs.searchMSTeams.apiServiceName, searchTeamsPayload as SearchParams);
+    useApiRequestCompletionState({
+        serviceName: Constants.pluginApiServiceConfigs.searchMSTeams.apiServiceName,
+        payload: searchTeamsPayload as SearchParams,
+        handleSuccess: () => {
+            if(searchedTeams) {
+                const suggestions: DropdownOptionType[] = [];
+                for(const team of searchedTeams as MSTeamsSearchResponse) {
+                    suggestions.push({
+                        label: team.display_name,
+                        value: team.id,
+                    })
+                }
+                setSearchSuggestions(suggestions);
+            }
+        },
+        handleError: (error) => {
+            // TODO: Handle this error
+        }
+    });
 
     return (
         <div className={className}>
@@ -30,12 +82,12 @@ const MicrosoftTeamPanel = ({
                 autoFocus={true}
                 fullWidth={true}
                 className={className}
-                items={teamOptions}
+                items={searchSuggestions}
                 onSelect={handleTeamSelect}
                 searchValue={searchTerm}
-                setSearchValue={setSearchTerm}
-                optionsLoading={optionsLoading}
+                setSearchValue={handleSearch}
                 onClearInput={handleClearInput}
+                optionsLoading={searchSuggestionsLoading}
             />
         </div>
     );

--- a/webapp/src/services/index.ts
+++ b/webapp/src/services/index.ts
@@ -50,5 +50,27 @@ export const msTeamsPluginApi = createApi({
                 responseHandler: (res) => res.text(),
             }),
         }),
+        [Constants.pluginApiServiceConfigs.searchMSTeams.apiServiceName]: builder.query<MSTeamsSearchResponse, SearchParams>({
+            query: (params) => ({
+                url: Constants.pluginApiServiceConfigs.searchMSTeams.path,
+                method: Constants.pluginApiServiceConfigs.searchMSTeams.method,
+                params: {...params},
+            }),
+        }),
+        [Constants.pluginApiServiceConfigs.searchMSChannels.apiServiceName]: builder.query<MSTeamsSearchResponse, SearchMSChannelsParams>({
+            query: ({teamId, ...params}) => ({
+                url: Constants.pluginApiServiceConfigs.searchMSChannels.path.replace('{team_id}', teamId),
+                method: Constants.pluginApiServiceConfigs.searchMSChannels.method,
+                params: {...params},
+            }),
+        }),
+        [Constants.pluginApiServiceConfigs.linkChannels.apiServiceName]: builder.query<string, LinkChannelsPayload>({
+            query: (payload) => ({
+                url: Constants.pluginApiServiceConfigs.linkChannels.path,
+                method: Constants.pluginApiServiceConfigs.linkChannels.method,
+                body: payload,
+                responseHandler: (res) => res.text(),
+            }),
+        }),
     }),
 });

--- a/webapp/src/types/common/index.d.ts
+++ b/webapp/src/types/common/index.d.ts
@@ -27,6 +27,13 @@ type ChannelLinkData = {
     msTeamsChannelType: string,
 }
 
+type MSTeamsSearchResponse = MSTeamOrChannel[];
+
+type MSTeamOrChannel = {
+    id: string,
+    display_name: string,
+}
+
 type DropdownOptionType = {
     label?: string;
     value: string;

--- a/webapp/src/types/common/payload.d.ts
+++ b/webapp/src/types/common/payload.d.ts
@@ -7,6 +7,17 @@ type UnlinkChannelParams = {
     channelId: string;
 }
 
-interface SearchLinkedChannelParams extends PaginationQueryParams {
+interface SearchParams extends PaginationQueryParams {
     search?: string;
+}
+
+interface SearchMSChannelsParams extends SearchParams {
+    teamId: string;
+}
+
+type LinkChannelsPayload = {
+    mattermostTeamID: string,
+    mattermostChannelID: string,
+    msTeamsTeamID: string,
+    msTeamsChannelID: string,
 }

--- a/webapp/src/types/common/service.d.ts
+++ b/webapp/src/types/common/service.d.ts
@@ -5,7 +5,10 @@ type PluginApiServiceName =
     'connect' |
     'getLinkedChannels' |
     'disconnectUser' |
-    'unlinkChannel';
+    'unlinkChannel' |
+    'searchMSTeams' |
+    'searchMSChannels'|
+    'linkChannels';
 
 type PluginApiService = {
     path: string,
@@ -18,4 +21,4 @@ type APIError = {
     data: string,
 }
 
-type APIRequestPayload = PaginationQueryParams | UnlinkChannelParams | SearchLinkedChannelParams | void;
+type APIRequestPayload = PaginationQueryParams | UnlinkChannelParams | SearchParams | LinkChannelsPayload | void;

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -1195,10 +1195,8 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@brightscout/mattermost-ui-library@2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@brightscout/mattermost-ui-library/-/mattermost-ui-library-2.0.9.tgz#b5a767bfa64f01284785b382d1b4f5381e1938f5"
-  integrity sha512-DtXJEbezXCZkbx/sgURE2JcxoxACMeZAW7iTlQnXp6xzHLq3S9iY2ruNJMMI7VIf8c/MnZt/YBSglOiKWJUVIw==
+"@brightscout/mattermost-ui-library@file:../../mm-ui-library":
+  version "2.3.0"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
#### Summary
- Created new services, constants, types for the request bodies and params of the new APIs
- Added the logic of fetching MM teams when the MM team panel opens as there is no search API
- Added the logic of searching MM channels inside a team using MM REST API
- Added the logic of searching MS teams and channels using the plugin API
- Added json descriptors for two structs in client.go file
- Changed the dependency version for the MM UI library with a TODO comment

#### Ticket Link
None