### PR TITLE
add recovery handler for activity handler worker

### DIFF
--- a/server/handlers/recovery_handler.go
+++ b/server/handlers/recovery_handler.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func goWithRecovery(name string, doStart func(), isQuitting func() bool, logError func(msg string, keyValuePairs ...any)) {
+	var doRecoverableStart func()
+
+	// doRecover is a helper function to recover from panics and restart the goroutine.
+	doRecover := func() {
+		if isQuitting() {
+			return
+		}
+
+		if r := recover(); r != nil {
+			logError(fmt.Sprintf("Recovering from panic in %s", name), "panic", r, "stack", string(debug.Stack()))
+		} else {
+			logError(fmt.Sprintf("Recovering from unexpected exit in %s", name), "stack", string(debug.Stack()))
+		}
+
+		go doRecoverableStart()
+	}
+
+	// doRecoverableStart delegates to doStart, automatically recovering from panics by
+	// launching a fresh goroutine on doStart as needed.
+	doRecoverableStart = func() {
+		defer doRecover()
+		doStart()
+	}
+
+	go doRecoverableStart()
+}

--- a/server/handlers/recovery_handler_test.go
+++ b/server/handlers/recovery_handler_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func assertReceive[X any](t *testing.T, c chan X, failureMessage string) {
+	select {
+	case <-c:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, failureMessage)
+	}
+}
+
+func TestGoWithRecovery(t *testing.T) {
+	// makeDoStart simulates a start function with the defined sequence of actions, whether to
+	// do a "normal" run, waiting for the signal to stop, to "panic", immediately crashing,
+	// or to unexpectedly "exit".
+	makeDoStart := func(t *testing.T, sequence []string, started chan int, stopping, stopped chan bool) (func(), func(string, ...any)) {
+		count := 0
+
+		doStart := func() {
+			started <- count
+			defer func() {
+				count++
+			}()
+
+			require.Less(t, count, len(sequence), "unexpected number of invocations")
+
+			switch sequence[count] {
+			case "normal":
+				// Wait for shut down
+				<-stopping
+				close(stopped)
+
+			case "panic":
+				panic("doStart panic")
+
+			case "exit":
+				return
+
+			default:
+				require.Failf(t, "unexpected sequence", "got %s", sequence[count])
+			}
+		}
+
+		logError := func(msg string, keyValuePairs ...any) {
+			// logError gets called after count++
+			actualCount := count - 1
+
+			require.Less(t, actualCount, len(sequence), "unexpected number of invocations")
+
+			switch sequence[actualCount] {
+			case "normal":
+				require.Failf(t, "should not log error", "got %v", msg)
+			case "panic":
+				require.Equal(t, "Recovering from panic in job", msg)
+			case "exit":
+				require.Equal(t, "Recovering from unexpected exit in job", msg)
+			default:
+				require.Failf(t, "unexpected sequence", "got %s", sequence[actualCount])
+			}
+		}
+
+		return doStart, logError
+	}
+
+	t.Run("quitting normally does not recover", func(t *testing.T) {
+		started := make(chan int)
+		stopping := make(chan bool)
+		stopped := make(chan bool)
+
+		doStart, logError := makeDoStart(t, []string{"normal"}, started, stopping, stopped)
+		isQuitting := func() bool {
+			select {
+			case <-stopping:
+				return true
+			default:
+				return false
+			}
+		}
+
+		goWithRecovery("job", doStart, isQuitting, logError)
+		assertReceive(t, started, "doStart failed to start")
+		close(stopping)
+		assertReceive(t, stopped, "doStart failed to finish")
+	})
+
+	t.Run("single panic recovers", func(t *testing.T) {
+		started := make(chan int)
+		stopping := make(chan bool)
+		stopped := make(chan bool)
+
+		doStart, logError := makeDoStart(t, []string{"panic", "normal"}, started, stopping, stopped)
+		isQuitting := func() bool {
+			select {
+			case <-stopping:
+				return true
+			default:
+				return false
+			}
+		}
+
+		goWithRecovery("job", doStart, isQuitting, logError)
+		assertReceive(t, started, "doStart failed to start")
+		assertReceive(t, started, "doStart failed to start the second time")
+		close(stopping)
+		assertReceive(t, stopped, "doStart failed to finish")
+	})
+
+	t.Run("unexpected exit recovers", func(t *testing.T) {
+		started := make(chan int)
+		stopping := make(chan bool)
+		stopped := make(chan bool)
+
+		doStart, logError := makeDoStart(t, []string{"exit", "normal"}, started, stopping, stopped)
+		isQuitting := func() bool {
+			select {
+			case <-stopping:
+				return true
+			default:
+				return false
+			}
+		}
+
+		goWithRecovery("job", doStart, isQuitting, logError)
+		assertReceive(t, started, "doStart failed to start")
+		assertReceive(t, started, "doStart failed to start the second time")
+		close(stopping)
+		assertReceive(t, stopped, "doStart failed to finish")
+	})
+
+	t.Run("multiple panics and unexpected exits recover", func(t *testing.T) {
+		started := make(chan int)
+		stopping := make(chan bool)
+		stopped := make(chan bool)
+
+		doStart, logError := makeDoStart(t, []string{"panic", "panic", "exit", "normal"}, started, stopping, stopped)
+		isQuitting := func() bool {
+			select {
+			case <-stopping:
+				return true
+			default:
+				return false
+			}
+		}
+
+		goWithRecovery("job", doStart, isQuitting, logError)
+		assertReceive(t, started, "doStart failed to start")
+		assertReceive(t, started, "doStart failed to start the second time")
+		assertReceive(t, started, "doStart failed to start the third time")
+		assertReceive(t, started, "doStart failed to start the fourth time")
+		close(stopping)
+		assertReceive(t, stopped, "doStart failed to finish")
+	})
+}


### PR DESCRIPTION
#### Summary
Copy the strategy used by the [web hub](https://github.com/mattermost/mattermost/blob/5e94af13022d16dd29c079bc2a68c84a5bac6e9e/server/channels/app/platform/web_hub.go#L370-L375) in the Mattermost server to recover from panics in the activity handler worker.

Extract the logic and add unit tests for normal execution, panics, unexpected exits, and a mixture of all three.

Before, hitting the `/plugins/com.mattermost.msteams-sync/changes` endpoint with a hard-coded panic:
```
{"timestamp":"2023-11-21 17:33:06.917 -04:00","level":"debug","msg":"panic: Here","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.917 -04:00","level":"debug","msg":"","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.917 -04:00","level":"debug","msg":"goroutine 128 [running]:","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.918 -04:00","level":"debug","msg":"github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.(*ActivityHandler).handleActivity(0x14000912280, {{0x0, 0x0}, {0x14000501020, 0x20}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...})","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.918 -04:00","level":"debug","msg":"\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/handlers.go:160 +0x8c","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.918 -04:00","level":"debug","msg":"github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.(*ActivityHandler).Start.func1()","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.918 -04:00","level":"debug","msg":"\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/handlers.go:92 +0x170","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.918 -04:00","level":"debug","msg":"created by github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.(*ActivityHandler).Start in goroutine 106","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.918 -04:00","level":"debug","msg":"\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/handlers.go:87 +0xc4","caller":"plugin/hclog_adapter.go:54","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:06.919 -04:00","level":"error","msg":"plugin process exited","caller":"plugin/hclog_adapter.go:79","plugin_id":"com.mattermost.msteams-sync","wrapped_extras":"pathplugins/com.mattermost.msteams-sync/server/dist/plugin-darwin-arm64pid29209errorexit status 2"}
{"timestamp":"2023-11-21 17:33:06.919 -04:00","level":"error","msg":"Plugin failed to ServeHTTP, RPC call failed","caller":"plugin/client_rpc.go:423","plugin_id":"com.mattermost.msteams-sync","error":"unexpected EOF"}
{"timestamp":"2023-11-21 17:33:34.109 -04:00","level":"warn","msg":"Health check failed for plugin","caller":"plugin/health_check.go:59","id":"com.mattermost.msteams-sync","error":"plugin RPC connection is not responding"}
{"timestamp":"2023-11-21 17:33:34.109 -04:00","level":"debug","msg":"Restarting plugin due to failed health check","caller":"plugin/health_check.go:72","id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:34.109 -04:00","level":"error","msg":"RPC call OnDeactivate to plugin failed.","caller":"plugin/client_rpc_generated.go:33","plugin_id":"com.mattermost.msteams-sync","error":"connection is shut down"}
{"timestamp":"2023-11-21 17:33:34.109 -04:00","level":"warn","msg":"error closing client during Kill","caller":"plugin/hclog_adapter.go:70","plugin_id":"com.mattermost.msteams-sync","wrapped_extras":"errconnection is shut down"}
{"timestamp":"2023-11-21 17:33:34.109 -04:00","level":"warn","msg":"plugin failed to exit gracefully","caller":"plugin/hclog_adapter.go:72","plugin_id":"com.mattermost.msteams-sync"}
{"timestamp":"2023-11-21 17:33:34.294 -04:00","level":"debug","msg":"starting plugin","caller":"plugin/hclog_adapter.go:52","plugin_id":"com.mattermost.msteams-sync","wrapped_extras":"pathplugins/com.mattermost.msteams-sync/server/dist/plugin-darwin-arm64args[plugins/com.mattermost.msteams-sync/server/dist/plugin-darwin-arm64]"}
{"timestamp":"2023-11-21 17:33:34.299 -04:00","level":"debug","msg":"plugin started","caller":"plugin/hclog_adapter.go:52","plugin_id":"com.mattermost.msteams-sync","wrapped_extras":"pathplugins/com.mattermost.msteams-sync/server/dist/plugin-darwin-arm64pid29323"}
```

after, with the same hard-coded panic:
```
{"timestamp":"2023-11-21 17:43:09.746 -04:00","level":"error","msg":"Recovering from panic in activity handler worker","caller":"app/plugin_api.go:988","plugin_id":"com.mattermost.msteams-sync","panic":"Here","stack":"goroutine 135 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x64\ngithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.goWithRecovery.func1()\n\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/recovery_handler.go:18 +0x120\npanic({0x1047df4e0?, 0x105c5cd70?})\n\truntime/panic.go:920 +0x254\ngithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.(*ActivityHandler).handleActivity(0x1400059a050, {{0x0, 0x0}, {0x1400068e260, 0x20}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...})\n\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/handlers.go:175 +0xc0\ngithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.(*ActivityHandler).Start.func1()\n\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/handlers.go:96 +0x180\ngithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.goWithRecovery.func2()\n\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/recovery_handler.go:30 +0x50\ncreated by github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers.goWithRecovery in goroutine 118\n\tgithub.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/recovery_handler.go:33 +0x23c\n"}
```



#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-55499