### PR TITLE
[MI-3771] Add padding to enforced connected account modal

### DIFF
--- a/webapp/src/components/enforceConnectedAccountModal.css
+++ b/webapp/src/components/enforceConnectedAccountModal.css
@@ -11,6 +11,7 @@
     justify-content: center;
     align-items: center;
     padding: 20px;
+    text-align: center;
 }
 
 .EnforceConnectedAccountModal img {
@@ -29,8 +30,4 @@
 
 .EnforceConnectedAccountModal .connectMessage {
     font-size: 18px;
-}
-
-.EnforceConnectedAccountModal .body-text {
-    text-align: center;
 }

--- a/webapp/src/components/enforceConnectedAccountModal.css
+++ b/webapp/src/components/enforceConnectedAccountModal.css
@@ -30,3 +30,7 @@
 .EnforceConnectedAccountModal .connectMessage {
     font-size: 18px;
 }
+
+.EnforceConnectedAccountModal .body-text {
+    text-align: center;
+}

--- a/webapp/src/components/enforceConnectedAccountModal.css
+++ b/webapp/src/components/enforceConnectedAccountModal.css
@@ -10,6 +10,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    padding: 20px;
 }
 
 .EnforceConnectedAccountModal img {

--- a/webapp/src/components/enforceConnectedAccountModal.tsx
+++ b/webapp/src/components/enforceConnectedAccountModal.tsx
@@ -56,8 +56,8 @@ export default function EnforceConnectedAccountModal() {
     return (
         <div className='EnforceConnectedAccountModal'>
             <img src={iconURL}/>
-            <h1 className='body-text'>{'Connect your Microsoft Teams Account'}</h1>
-            {!connecting && <p className='body-text'>{'For using this server you need to connect your Mattermost account with your MS Teams account, to procced just click in the button'}</p>}
+            <h1>{'Connect your Microsoft Teams Account'}</h1>
+            {!connecting && <p>{'This server requires you to connect your Mattermost account with your Microsoft Teams account.'}</p>}
             {!connecting && (
                 <button
                     className='btn btn-primary'

--- a/webapp/src/components/enforceConnectedAccountModal.tsx
+++ b/webapp/src/components/enforceConnectedAccountModal.tsx
@@ -56,8 +56,8 @@ export default function EnforceConnectedAccountModal() {
     return (
         <div className='EnforceConnectedAccountModal'>
             <img src={iconURL}/>
-            <h1>{'Connect your Microsoft Teams Account'}</h1>
-            {!connecting && <p>{'For using this server you need to connect your Mattermost account with your MS Teams account, to procced just click in the button'}</p>}
+            <h1 className='body-text'>{'Connect your Microsoft Teams Account'}</h1>
+            {!connecting && <p className='body-text'>{'For using this server you need to connect your Mattermost account with your MS Teams account, to procced just click in the button'}</p>}
             {!connecting && (
                 <button
                     className='btn btn-primary'


### PR DESCRIPTION
#### Summary

- Add padding to enforced connected account modal
- Updated text content of the modal

#### Screenshots
![image](https://github.com/mattermost/mattermost-plugin-msteams-sync/assets/100013900/a69507e2-59c6-402c-bf95-37f2ce599e71)
![image](https://github.com/mattermost/mattermost-plugin-msteams-sync/assets/100013900/a0586176-75ad-4cff-a422-36d45eb0463a)
![image](https://github.com/mattermost/mattermost-plugin-msteams-sync/assets/100013900/92d6ebb1-6bf2-4a20-bd55-8fe73c258943)
![image](https://github.com/mattermost/mattermost-plugin-msteams-sync/assets/100013900/cac7c704-5402-41a2-96d9-e51f8e936ece)


