### PR TITLE
MM-55491: ensure handlers stop

### DIFF
--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/enescakir/emoji"
@@ -56,7 +55,7 @@ type ActivityHandler struct {
 	plugin               PluginIface
 	queue                chan msteams.Activity
 	quit                 chan bool
-	quitting             atomic.Bool
+	workersWaitGroup     sync.WaitGroup
 	IgnorePluginHooksMap sync.Map
 }
 
@@ -82,7 +81,7 @@ func New(plugin PluginIface) *ActivityHandler {
 }
 
 func (ah *ActivityHandler) Start() {
-	ah.quitting.Store(false)
+	ah.quit = make(chan bool)
 
 	// This is constant for now, but report it as a metric to future proof dashboards.
 	ah.plugin.GetMetrics().ObserveChangeEventQueueCapacity(activityQueueSize)
@@ -101,25 +100,32 @@ func (ah *ActivityHandler) Start() {
 		}
 	}
 
+	// doQuit is called when the worker quits intentionally
+	doQuit := func() {
+		ah.workersWaitGroup.Done()
+	}
+
 	// isQuitting informs the recovery handler if the shutdown is intentional
 	isQuitting := func() bool {
-		return ah.quitting.Load()
+		select {
+		case <-ah.quit:
+			return true
+		default:
+			return false
+		}
 	}
 
 	logError := ah.plugin.GetAPI().LogError
 
 	for i := 0; i < numberOfWorkers; i++ {
-		startWorker(logError, ah.plugin.GetMetrics(), isQuitting, doStart)
+		ah.workersWaitGroup.Add(1)
+		startWorker(logError, ah.plugin.GetMetrics(), isQuitting, doStart, doQuit)
 	}
 }
 
 func (ah *ActivityHandler) Stop() {
-	ah.quitting.Store(true)
-	go func() {
-		for i := 0; i < numberOfWorkers; i++ {
-			ah.quit <- true
-		}
-	}()
+	close(ah.quit)
+	ah.workersWaitGroup.Wait()
 }
 
 func (ah *ActivityHandler) Handle(activity msteams.Activity) error {

--- a/server/handlers/worker.go
+++ b/server/handlers/worker.go
@@ -10,12 +10,13 @@ type workerMetrics interface {
 
 // startWorker wraps and invokes the given callback in a goroutine, automatically restarting in a
 // new goroutine on any unrecovered panic or unexpected termination.
-func startWorker(logError func(msg string, keyValuePairs ...any), metrics workerMetrics, isQuitting func() bool, callback func()) {
+func startWorker(logError func(msg string, keyValuePairs ...any), metrics workerMetrics, isQuitting func() bool, doStart, doQuit func()) {
 	var doRecoverableStart func()
 
 	// doRecover is a helper function to recover from panics and restart the goroutine.
 	doRecover := func() {
 		if isQuitting() {
+			doQuit()
 			return
 		}
 
@@ -33,7 +34,7 @@ func startWorker(logError func(msg string, keyValuePairs ...any), metrics worker
 	// launching a fresh goroutine on callback as needed.
 	doRecoverableStart = func() {
 		defer doRecover()
-		callback()
+		doStart()
 	}
 
 	go doRecoverableStart()


### PR DESCRIPTION
#### Summary
When the plugin stops normally – e.g. as part of rolling the k8s pods – it’s imperative that all outstanding requests be given a chance to terminate normally. Accordingly, let’s make `ActivityHandler.Stop` blocking.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-55491


