### PR TITLE
Bump plugin version to v1.4.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-sync/releases/tag/v0.1.0",
     "icon_path": "assets/msteams-sync-icon.svg",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "min_server_version": "7.8.10",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Bump plugin version to v1.4.0. (This won't be necessary at all once we update the tooling and the version is extracted from the nearest tag.)

#### Ticket Link
N/A