### PR TITLE
restore metrics server stop

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -280,6 +280,11 @@ func (p *Plugin) stop() {
 	if p.monitor != nil {
 		p.monitor.Stop()
 	}
+	if p.metricsServer != nil {
+		if err := p.metricsServer.Shutdown(); err != nil {
+			p.API.LogWarn("Error shutting down metrics server", "error", err)
+		}
+	}
 	if p.stopSubscriptions != nil {
 		p.stopSubscriptions()
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost-plugin-msteams-sync/pull/436, I incorrectly removed the `p.metricsServer.Shutdown()` call during `plugin.stop()`, believing it would incorrectly impact the new server managed `ServeMetrics` hook, but this wasn't true: we should indeed stop listening on the requested port if the configuration so changes, and we can continue handling `ServeMetrics` without issue.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-55507