### PR TITLE
remove unused syncSince implementation

### DIFF
--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -6,10 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/enescakir/emoji"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics"
@@ -28,7 +26,6 @@ var attachRE = regexp.MustCompile(`<attachment id=.*?attachment>`)
 var imageRE = regexp.MustCompile(`<img .*?>`)
 
 const (
-	lastReceivedChangeKey       = "last_received_change"
 	numberOfWorkers             = 50
 	activityQueueSize           = 5000
 	msteamsUserTypeGuest        = "Guest"
@@ -245,7 +242,6 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, acti
 	postInfo, _ := ah.plugin.GetStore().GetPostInfoByMSTeamsID(msg.ChatID+msg.ChannelID, msg.ID)
 	if postInfo != nil {
 		ah.plugin.GetAPI().LogDebug("duplicate post")
-		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		ah.plugin.GetMetrics().ObserveConfirmedMessage(metrics.ActionSourceMattermost, isDirectMessage)
 		return metrics.DiscardedReasonDuplicatedPost
 	}
@@ -253,7 +249,6 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, acti
 	msteamsUserID, _ := ah.plugin.GetStore().MattermostToTeamsUserID(ah.plugin.GetBotUserID())
 	if msg.UserID == msteamsUserID {
 		ah.plugin.GetAPI().LogDebug("Skipping messages from bot user")
-		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		return metrics.DiscardedReasonIsBotUser
 	}
 
@@ -329,7 +324,6 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, acti
 		})
 	}
 
-	ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 	if newPost != nil && newPost.Id != "" && msg.ID != "" {
 		if err := ah.plugin.GetStore().LinkPosts(nil, storemodels.PostInfo{MattermostID: newPost.Id, MSTeamsChannel: fmt.Sprintf(msg.ChatID + msg.ChannelID), MSTeamsID: msg.ID, MSTeamsLastUpdateAt: msg.LastUpdateAt}); err != nil {
 			ah.plugin.GetAPI().LogWarn("Error updating the MSTeams/Mattermost post link metadata", "error", err)
@@ -358,13 +352,11 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, acti
 	msteamsUserID, _ := ah.plugin.GetStore().MattermostToTeamsUserID(ah.plugin.GetBotUserID())
 	if msg.UserID == msteamsUserID {
 		ah.plugin.GetAPI().LogDebug("Skipping messages from bot user")
-		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		return metrics.DiscardedReasonIsBotUser
 	}
 
 	postInfo, _ := ah.plugin.GetStore().GetPostInfoByMSTeamsID(msg.ChatID+msg.ChannelID, msg.ID)
 	if postInfo == nil {
-		ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 		return metrics.DiscardedReasonOther
 	}
 
@@ -436,7 +428,6 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, acti
 
 	isDirectMessage := IsDirectMessage(activityIds.ChatID)
 	ah.plugin.GetMetrics().ObserveMessage(metrics.ActionUpdated, metrics.ActionSourceMSTeams, isDirectMessage)
-	ah.updateLastReceivedChangeDate(msg.LastUpdateAt)
 	ah.handleReactions(postInfo.MattermostID, channelID, isDirectMessage, msg.Reactions)
 	return metrics.DiscardedReasonNone
 }
@@ -533,13 +524,6 @@ func (ah *ActivityHandler) handleDeletedActivity(activityIds clientmodels.Activi
 	ah.plugin.GetMetrics().ObserveMessage(metrics.ActionDeleted, metrics.ActionSourceMSTeams, IsDirectMessage(activityIds.ChatID))
 
 	return metrics.DiscardedReasonNone
-}
-
-func (ah *ActivityHandler) updateLastReceivedChangeDate(t time.Time) {
-	err := ah.plugin.GetAPI().KVSet(lastReceivedChangeKey, []byte(strconv.FormatInt(t.UnixMicro(), 10)))
-	if err != nil {
-		ah.plugin.GetAPI().LogError("Unable to store properly the last received change")
-	}
 }
 
 func (ah *ActivityHandler) isActiveUser(userID string) bool {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -69,7 +69,6 @@ func newTestPlugin(t *testing.T) *Plugin {
 	config := model.Config{}
 	config.SetDefaults()
 	plugin.API.(*plugintest.API).On("KVGet", "cron_monitoring_system").Return(nil, nil).Times(1)
-	plugin.API.(*plugintest.API).On("KVGet", lastReceivedChangeKey).Return([]byte{}, nil).Times(1)
 	plugin.API.(*plugintest.API).On("GetServerVersion").Return("7.8.0")
 	plugin.API.(*plugintest.API).On("GetBundlePath").Return("./dist", nil)
 	plugin.API.(*plugintest.API).On("Conn", true).Return("connection-id", nil)
@@ -515,7 +514,7 @@ func TestStart(t *testing.T) {
 			test.SetupAPI(p.API.(*plugintest.API))
 			test.SetupClient(p.msteamsAppClient.(*mocks.Client))
 			test.SetupStore(p.store.(*storemocks.Store))
-			p.start(nil)
+			p.start()
 			time.Sleep(5 * time.Second)
 		})
 	}

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -423,67 +423,38 @@ func TestSyncUsers(t *testing.T) {
 	}
 }
 
-func TestConnectTeamsAppClient(t *testing.T) {
-	for _, test := range []struct {
-		Name          string
-		SetupAPI      func(*plugintest.API)
-		SetupClient   func(*mocks.Client)
-		ExpectedError string
-	}{
-		{
-			Name: "ConnectTeamsAppClient: Unable to connect to the app client",
-			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to connect to the app client", "error", mock.Anything).Times(1)
-			},
-			SetupClient: func(client *mocks.Client) {
-				client.On("Connect").Return(errors.New("unable to connect to the app client")).Times(1)
-			},
-			ExpectedError: "unable to connect to the app client",
-		},
-		{
-			Name:     "ConnectTeamsAppClient: Valid",
-			SetupAPI: func(api *plugintest.API) {},
-			SetupClient: func(client *mocks.Client) {
-				client.On("Connect").Return(nil).Times(1)
-			},
-		},
-	} {
-		t.Run(test.Name, func(t *testing.T) {
-			assert := assert.New(t)
-			p := newTestPlugin(t)
-			test.SetupAPI(p.API.(*plugintest.API))
-			test.SetupClient(p.msteamsAppClient.(*mocks.Client))
-			err := p.connectTeamsAppClient()
-			if test.ExpectedError != "" {
-				assert.Contains(err.Error(), test.ExpectedError)
-			} else {
-				assert.Nil(err)
-			}
-		})
-	}
-}
-
 func TestStart(t *testing.T) {
 	mockSiteURL := "mockSiteURL"
 	for _, test := range []struct {
 		Name        string
+		IsRestart   bool
 		SetupAPI    func(*plugintest.API)
 		SetupClient func(*mocks.Client)
 		SetupStore  func(*storemocks.Store)
 	}{
 		{
-			Name: "Start: Unable to connect to the app client",
+			Name:      "Start: Valid",
+			IsRestart: false,
 			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to connect to the app client", "error", mock.Anything).Times(1)
-				api.On("LogError", "Unable to connect to the msteams", "error", mock.Anything).Times(1)
+				api.On("GetConfig").Return(&model.Config{
+					ServiceSettings: model.ServiceSettings{
+						SiteURL: &mockSiteURL,
+					},
+				})
+				api.On("LogError", "Unable to start the monitoring system", "error", "error in setting job status").Return()
 			},
 			SetupClient: func(client *mocks.Client) {
-				client.On("Connect").Return(errors.New("unable to connect to the app client")).Times(1)
+				client.On("Connect").Return(nil).Times(1)
 			},
-			SetupStore: func(s *storemocks.Store) {},
+			SetupStore: func(s *storemocks.Store) {
+				s.On("SetJobStatus", "monitoring_system", false).Return(errors.New("error in setting job status"))
+				s.On("CompareAndSetJobStatus", "monitoring_system", false, true).Return(false, nil)
+				s.On("DeleteFakeSubscriptions").Return(nil).Times(1)
+			},
 		},
 		{
-			Name: "Start: Valid",
+			Name:      "Restart: Valid",
+			IsRestart: true,
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetConfig").Return(&model.Config{
 					ServiceSettings: model.ServiceSettings{
@@ -514,7 +485,7 @@ func TestStart(t *testing.T) {
 			test.SetupAPI(p.API.(*plugintest.API))
 			test.SetupClient(p.msteamsAppClient.(*mocks.Client))
 			test.SetupStore(p.store.(*storemocks.Store))
-			p.start()
+			p.start(test.IsRestart)
 			time.Sleep(5 * time.Second)
 		})
 	}


### PR DESCRIPTION
#### Summary
Remove some unused code in anticipation of `start`/`stop` refactoring. In addition to removing the unused `syncSince` implementation (to be replaced with our holistic resiliency efforts), this code rips out the `last_received_change` handling altogether, since we need it per-subscription.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-55494