### PR TITLE
MM-55490: dont reset on configuration changes

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -176,7 +176,7 @@ func (p *Plugin) connectTeamsAppClient() error {
 	return nil
 }
 
-func (p *Plugin) start() {
+func (p *Plugin) start(isRestart bool) {
 	enableMetrics := p.API.GetConfig().MetricsSettings.Enable
 
 	if enableMetrics != nil && *enableMetrics {
@@ -186,7 +186,10 @@ func (p *Plugin) start() {
 		p.runMetricsUpdaterTask(p.store, updateMetricsTaskFrequency)
 	}
 
-	p.activityHandler.Start()
+	// We don't restart the activity handler since it's stateless.
+	if !isRestart {
+		p.activityHandler.Start()
+	}
 
 	err := p.connectTeamsAppClient()
 	if err != nil {
@@ -266,7 +269,7 @@ func (p *Plugin) getPrivateKey() (*rsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
-func (p *Plugin) stop() {
+func (p *Plugin) stop(isRestart bool) {
 	if p.monitor != nil {
 		p.monitor.Stop()
 	}
@@ -274,7 +277,9 @@ func (p *Plugin) stop() {
 		p.stopSubscriptions()
 		time.Sleep(1 * time.Second)
 	}
-	if p.activityHandler != nil {
+
+	// We don't stop the activity handler on restart since it's stateless.
+	if !isRestart && p.activityHandler != nil {
 		p.activityHandler.Stop()
 	}
 
@@ -282,8 +287,8 @@ func (p *Plugin) stop() {
 }
 
 func (p *Plugin) restart() {
-	p.stop()
-	p.start()
+	p.stop(true)
+	p.start(true)
 }
 
 func (p *Plugin) generatePluginSecrets() error {
@@ -400,7 +405,7 @@ func (p *Plugin) OnActivate() error {
 		}
 	}()
 
-	go p.start()
+	go p.start(false)
 	return nil
 }
 
@@ -409,7 +414,7 @@ func (p *Plugin) OnDeactivate() error {
 		p.API.LogWarn("Error shutting down metrics server", "error", err)
 	}
 
-	p.stop()
+	p.stop(false)
 	return nil
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -158,16 +158,20 @@ func (p *Plugin) connectTeamsAppClient() error {
 	p.msteamsAppClientMutex.Lock()
 	defer p.msteamsAppClientMutex.Unlock()
 
-	if p.msteamsAppClient == nil {
-		msteamsAppClient := msteams.NewApp(
-			p.getConfiguration().TenantID,
-			p.getConfiguration().ClientID,
-			p.getConfiguration().ClientSecret,
-			&p.apiClient.Log,
-		)
-
-		p.msteamsAppClient = client_timerlayer.New(msteamsAppClient, p.GetMetrics())
+	// We don't currently support reconnecting with a new configuration: a plugin restart is
+	// required.
+	if p.msteamsAppClient != nil {
+		return nil
 	}
+
+	msteamsAppClient := msteams.NewApp(
+		p.getConfiguration().TenantID,
+		p.getConfiguration().ClientID,
+		p.getConfiguration().ClientSecret,
+		&p.apiClient.Log,
+	)
+
+	p.msteamsAppClient = client_timerlayer.New(msteamsAppClient, p.GetMetrics())
 	err := p.msteamsAppClient.Connect()
 	if err != nil {
 		p.API.LogError("Unable to connect to the app client", "error", err)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -423,46 +423,6 @@ func TestSyncUsers(t *testing.T) {
 	}
 }
 
-func TestConnectTeamsAppClient(t *testing.T) {
-	for _, test := range []struct {
-		Name          string
-		SetupAPI      func(*plugintest.API)
-		SetupClient   func(*mocks.Client)
-		ExpectedError string
-	}{
-		{
-			Name: "ConnectTeamsAppClient: Unable to connect to the app client",
-			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to connect to the app client", "error", mock.Anything).Times(1)
-			},
-			SetupClient: func(client *mocks.Client) {
-				client.On("Connect").Return(errors.New("unable to connect to the app client")).Times(1)
-			},
-			ExpectedError: "unable to connect to the app client",
-		},
-		{
-			Name:     "ConnectTeamsAppClient: Valid",
-			SetupAPI: func(api *plugintest.API) {},
-			SetupClient: func(client *mocks.Client) {
-				client.On("Connect").Return(nil).Times(1)
-			},
-		},
-	} {
-		t.Run(test.Name, func(t *testing.T) {
-			assert := assert.New(t)
-			p := newTestPlugin(t)
-			test.SetupAPI(p.API.(*plugintest.API))
-			test.SetupClient(p.msteamsAppClient.(*mocks.Client))
-			err := p.connectTeamsAppClient()
-			if test.ExpectedError != "" {
-				assert.Contains(err.Error(), test.ExpectedError)
-			} else {
-				assert.Nil(err)
-			}
-		})
-	}
-}
-
 func TestStart(t *testing.T) {
 	mockSiteURL := "mockSiteURL"
 	for _, test := range []struct {
@@ -472,18 +432,6 @@ func TestStart(t *testing.T) {
 		SetupClient func(*mocks.Client)
 		SetupStore  func(*storemocks.Store)
 	}{
-		{
-			Name:      "Start: Unable to connect to the app client",
-			IsRestart: false,
-			SetupAPI: func(api *plugintest.API) {
-				api.On("LogError", "Unable to connect to the app client", "error", mock.Anything).Times(1)
-				api.On("LogError", "Unable to connect to the msteams", "error", mock.Anything).Times(1)
-			},
-			SetupClient: func(client *mocks.Client) {
-				client.On("Connect").Return(errors.New("unable to connect to the app client")).Times(1)
-			},
-			SetupStore: func(s *storemocks.Store) {},
-		},
 		{
 			Name:      "Start: Valid",
 			IsRestart: false,


### PR DESCRIPTION
#### Summary
When I originally drafted the linked ticket, I imagined we would completely eliminate the `p.restart()` method and just keep all the jobs running all the time, with any configuration changes being resolved at run time. This turned out to be trickier than I expected, so I constrained to the primary focus of the overarching epic: avoid anything that disrupts the correct functioning of the application.

With that constrained focus, I'm only preventing the reset of two things: the main app client, and the activity handlers. The jobs being reset are "fine" because they aren't directly user facing. But imagine for a moment that we stop the activity handlers and then go to stop the users sync job, but it's running, so it takes a while: all the time the activity handlers are shut down and the change event queue is theoretically backing up. So we avoid this altogether.

Not reconnecting the app client is just a recognition of the fact that we never supported a "new configuration" in this method in the first place. In principle, we could extend this to only reconnect if we detect a change in tenant id, etc., but it's out of scope for this epic.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-55490
