### PR TITLE
Restoring the generate make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,12 @@ ifneq ($(HAS_WEBAPP),)
 endif
 	rm -fr build/bin/
 
+## Build the generated code
+generate: export PATH := $(GOBIN):$(PATH)
+generate:
+	$(GO) install github.com/vektra/mockery/v2/...@v2.18.0
+	cd server && $(GO) generate ./...
+
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@cat Makefile build/*.mk | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z0-9_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort


### PR DESCRIPTION
After the update of the starter template, the `make generate` command disappeared, and it was convenient to generate layers and mocks. This PR restores it.