### PR TITLE
MM-56364: fix metrics stop on configuration change

### DIFF
--- a/server/metrics/dashboards/cloud.json
+++ b/server/metrics/dashboards/cloud.json
@@ -25,7 +25,7 @@
           "uid": "${datasource}"
         },
         "enable": true,
-        "expr": "msteams_connect_system_plugin_start_time{namespace=\"$namespace\"} * 1000",
+        "expr": "msteams_connect_system_plugin_start_timestamp_seconds{namespace=\"$namespace\"} * 1000",
         "iconColor": "green",
         "name": "Plugin Start",
         "target": {
@@ -63,7 +63,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 292,
+  "id": 306,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -138,7 +138,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_connected_users_total{namespace=~\"$namespace\"})",
+          "expr": "avg(msteams_connect_app_connected_users{namespace=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "Connected Users",
           "range": true,
@@ -202,7 +202,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_synthetic_users_total{namespace=~\"$namespace\"})",
+          "expr": "avg(msteams_connect_app_synthetic_users{namespace=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "Synthetic Users",
           "range": true,
@@ -270,7 +270,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(msteams_connect_app_linked_channels_total{namespace=~\"$namespace\"})",
+          "expr": "avg(msteams_connect_app_linked_channels{namespace=~\"$namespace\"})",
           "instant": false,
           "legendFormat": "Linked Channels",
           "range": true,
@@ -570,7 +570,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[5m])) by (instance)",
+          "expr": "sum(rate(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[5m])) by (instance)",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -582,7 +582,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[5m]))",
+          "expr": "sum(rate(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[5m]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
@@ -894,7 +894,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_db_store_time_bucket{namespace=\"$namespace\"}[5m])) by (instance,le))",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_db_store_time_seconds_bucket{namespace=\"$namespace\"}[5m])) by (instance,le))",
           "instant": false,
           "legendFormat": "p99 ({{instance}})",
           "range": true,
@@ -906,7 +906,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_db_store_time_bucket{namespace=\"$namespace\"}[5m])) by (instance,le))",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_db_store_time_seconds_bucket{namespace=\"$namespace\"}[5m])) by (instance,le))",
           "hide": false,
           "instant": false,
           "legendFormat": "p50 ({{instance}})",
@@ -1017,7 +1017,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_api_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_api_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
           "instant": false,
           "legendFormat": "p99 ({{instance}})",
           "range": true,
@@ -1029,7 +1029,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_api_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_api_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
           "hide": false,
           "instant": false,
           "legendFormat": "p50 ({{instance}})",
@@ -1140,7 +1140,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\",method=~\"$top_db_count\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\",method=~\"$top_db_count\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{method}}",
           "range": true,
@@ -1250,7 +1250,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_api_time_count{namespace=~\"$namespace\"}[5m])) by (handler)",
+          "expr": "sum(increase(msteams_connect_api_time_seconds_count{namespace=~\"$namespace\"}[5m])) by (handler)",
           "instant": false,
           "legendFormat": "{{handler}}",
           "range": true,
@@ -1355,7 +1355,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_db_store_time_sum{namespace=\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method) / sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\",method=~\"$top_db_latency\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{method}}",
           "range": true,
@@ -1469,7 +1469,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_api_time_sum{namespace=~\"$namespace\"}[5m])) by (handler) / sum(increase(msteams_connect_api_time_count{namespace=~\"$namespace\"}[5m])) by (handler)",
+          "expr": "sum(increase(msteams_connect_api_time_seconds_sum{namespace=~\"$namespace\"}[5m])) by (handler) / sum(increase(msteams_connect_api_time_seconds_count{namespace=~\"$namespace\"}[5m])) by (handler)",
           "instant": false,
           "legendFormat": "{{handler}}",
           "range": true,
@@ -1602,7 +1602,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",success=\"true\"}[5m])) by (instance)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success=\"true\"}[5m])) by (instance)",
           "instant": false,
           "legendFormat": "Requests ({{instance}})",
           "range": true,
@@ -1614,7 +1614,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) by (instance)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) by (instance)",
           "hide": false,
           "instant": false,
           "legendFormat": "Errors ({{instance}})",
@@ -1627,7 +1627,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\"}[5m]))",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\"}[5m]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
@@ -1757,7 +1757,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) by (instance)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m])) by (instance)",
           "hide": false,
           "instant": false,
           "legendFormat": "Errors ({{instance}})",
@@ -1770,7 +1770,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",success!=\"true\"}[5m]))",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",success!=\"true\"}[5m]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
@@ -1880,7 +1880,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_count\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_count\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{handler}}",
           "range": true,
@@ -1989,7 +1989,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_msgraph_client_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "expr": "histogram_quantile(0.99, sum(rate(msteams_connect_msgraph_client_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
           "instant": false,
           "legendFormat": "p99 ({{instance}})",
           "range": true,
@@ -2001,7 +2001,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_msgraph_client_time_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
+          "expr": "histogram_quantile(0.50, sum(rate(msteams_connect_msgraph_client_time_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (instance,le))",
           "hide": false,
           "instant": false,
           "legendFormat": "p50 ({{instance}})",
@@ -2087,7 +2087,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 60
       },
@@ -2117,7 +2117,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_sum{namespace=~\"$namespace\",method=~\"$top_msgraph_client_latency\"}[5m])) by (method) / sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_latency\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_seconds_sum{namespace=~\"$namespace\",method=~\"$top_msgraph_client_latency\"}[5m])) by (method) / sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_latency\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{handler}}",
           "range": true,
@@ -2340,7 +2340,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason=\"\"}[5m])) by (change_type)",
+          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\",discarded_reason=\"\"}[5m])) by (change_type)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2435,7 +2435,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
+          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2455,7 +2455,29 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "Infinity": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "0%"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "nan",
+                "result": {
+                  "color": "dark-yellow",
+                  "index": 0,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2502,7 +2524,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason!=\"\"}[15m]))",
+          "expr": "sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_change_events_total{namespace=\"$namespace\"}[15m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2597,7 +2619,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_lifecycle_event_total{namespace=\"$namespace\"}[5m])) by (event_type)",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\"}[5m])) by (event_type)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2692,7 +2714,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\",discarded_reason!=\"\"}[5m])) by (discarded_reason)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2712,7 +2734,29 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "Infinity": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "0%"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "nan",
+                "result": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2759,7 +2803,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_lifecycle_event_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_lifecycle_event_total{namespace=\"$namespace\",discarded_reason!=\"\"}[15m]))",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_lifecycle_events_total{namespace=\"$namespace\"}[15m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2854,24 +2898,11 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_subscriptions_count{namespace=\"$namespace\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_subscriptions_total{namespace=\"$namespace\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "{{action}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_subscriptions_count{namespace=\"$namespace\",source=\"msteams\"}[5m]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "C"
         }
       ],
       "title": "Subscriptions (per second)",
@@ -2962,7 +2993,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_messages_total{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Direct ({{action}})",
           "range": true,
@@ -2974,7 +3005,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_messages_total{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Channel ({{action}})",
@@ -2987,7 +3018,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_messages_total{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Total ({{action}})",
@@ -3083,7 +3114,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_messages_total{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Direct ({{action}})",
           "range": true,
@@ -3095,7 +3126,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_messages_total{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Channel ({{action}})",
@@ -3108,7 +3139,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_messages_count{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_messages_total{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Total ({{action}})",
@@ -3204,7 +3235,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_reactions_total{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Direct ({{action}})",
           "range": true,
@@ -3216,7 +3247,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_reactions_total{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Channel ({{action}})",
@@ -3229,8 +3260,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
-          "hide": false,
+          "expr": "sum(rate(msteams_connect_events_reactions_total{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Total ({{action}})",
           "range": true,
@@ -3325,7 +3355,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_reactions_total{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Direct ({{action}})",
           "range": true,
@@ -3337,7 +3367,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_reactions_total{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Channel ({{action}})",
@@ -3350,7 +3380,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_reactions_count{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_reactions_total{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Total ({{action}})",
@@ -3446,7 +3476,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_files_total{namespace=\"$namespace\",source=\"mattermost\",is_direct=\"true\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Direct ({{action}})",
           "range": true,
@@ -3458,7 +3488,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_files_total{namespace=\"$namespace\",source=\"mattermost\",is_direct!=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Channel ({{action}})",
@@ -3471,7 +3501,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_files_total{namespace=\"$namespace\",source=\"mattermost\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Total ({{action}})",
@@ -3567,7 +3597,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_files_total{namespace=\"$namespace\",source=\"msteams\",is_direct=\"true\"}[5m])) by (action)",
           "instant": false,
           "legendFormat": "Direct ({{action}})",
           "range": true,
@@ -3579,7 +3609,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_files_total{namespace=\"$namespace\",source=\"msteams\",is_direct!=\"true\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Channel ({{action}})",
@@ -3592,7 +3622,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(msteams_connect_events_files_count{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
+          "expr": "sum(rate(msteams_connect_events_files_total{namespace=\"$namespace\",source=\"msteams\"}[5m])) by (action)",
           "hide": false,
           "instant": false,
           "legendFormat": "Total ({{action}})",
@@ -4088,8 +4118,8 @@
       {
         "current": {
           "selected": false,
-          "text": "w1343szyubdr7rkwouxwwjt89c",
-          "value": "w1343szyubdr7rkwouxwwjt89c"
+          "text": "",
+          "value": ""
         },
         "description": "The namespace (installation ID) by which to filter the graphs.",
         "hide": 0,
@@ -4098,11 +4128,11 @@
         "options": [
           {
             "selected": true,
-            "text": "w1343szyubdr7rkwouxwwjt89c",
-            "value": "w1343szyubdr7rkwouxwwjt89c"
+            "text": "",
+            "value": ""
           }
         ],
-        "query": "w1343szyubdr7rkwouxwwjt89c",
+        "query": "",
         "skipUrlSync": false,
         "type": "textbox"
       },
@@ -4127,6 +4157,7 @@
         "name": "top_plugin_api_count",
         "options": [],
         "query": {
+          "qryType": 3,
           "query": "query_result(topk(10, sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\"}[${__range_s}s])) by (api_name)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
@@ -4157,6 +4188,7 @@
         "name": "top_plugin_api_latency",
         "options": [],
         "query": {
+          "qryType": 3,
           "query": "query_result(topk(10, sum(increase(mattermost_plugin_api_time_sum{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\"}[${__range_s}s])) by (api_name) / sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\"}[${__range_s}s])) by (api_name)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
@@ -4169,8 +4201,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus Prod",
-          "value": "P27C405C01959D762"
+          "text": "Prometheus Test",
+          "value": "P3497915E6DC419FB"
         },
         "description": "The Prometheus data source from which to query.",
         "hide": 0,
@@ -4199,14 +4231,15 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "top_db_count",
         "options": [],
         "query": {
-          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "qryType": 3,
+          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -4229,14 +4262,15 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "top_db_latency",
         "options": [],
         "query": {
-          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "qryType": 3,
+          "query": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_seconds_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -4259,7 +4293,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
         "description": "",
         "hide": 2,
         "includeAll": true,
@@ -4267,7 +4301,8 @@
         "name": "top_msgraph_client_count",
         "options": [],
         "query": {
-          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "qryType": 3,
+          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -4290,7 +4325,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
         "description": "",
         "hide": 2,
         "includeAll": true,
@@ -4298,7 +4333,8 @@
         "name": "top_msgraph_client_latency",
         "options": [],
         "query": {
-          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "qryType": 3,
+          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_seconds_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -4315,8 +4351,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "MSTeams Connect",
-  "uid": "c39b4ded-2384-4775-8e7a-5456fb65fecf",
-  "version": 10,
+  "title": "MSTeams Connect (v2, Renamed Metrics)",
+  "uid": "c97b2768-e8bd-42fb-92e4-ad26dbf943db",
+  "version": 8,
   "weekStart": ""
 }

--- a/server/metrics/dashboards/cloud.json
+++ b/server/metrics/dashboards/cloud.json
@@ -127,9 +127,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -190,9 +191,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -257,9 +259,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -335,9 +338,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -426,9 +430,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -471,6 +476,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -608,6 +614,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -808,6 +815,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -906,7 +914,7 @@
           "refId": "B"
         }
       ],
-      "title": "Store Latency",
+      "title": "DB Latency",
       "transformations": [
         {
           "id": "renameByRegex",
@@ -930,6 +938,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1052,6 +1061,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1073,7 +1083,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1090,7 +1101,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1159,6 +1171,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1180,7 +1193,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1197,7 +1211,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1257,6 +1272,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1278,7 +1294,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1295,7 +1312,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1344,7 +1362,7 @@
           "refId": "A"
         }
       ],
-      "title": "DB calls by duration",
+      "title": "DB calls by Duration",
       "transformations": [
         {
           "id": "renameByRegex",
@@ -1368,6 +1386,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1389,7 +1408,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1406,7 +1426,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1483,6 +1504,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1521,7 +1543,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1636,6 +1659,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1674,7 +1698,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1777,6 +1802,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1798,7 +1824,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1853,7 +1880,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_count\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{handler}}",
           "range": true,
@@ -1884,6 +1911,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2005,6 +2033,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2026,7 +2055,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 2,
+              "type": "log"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -2057,7 +2087,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 60
       },
@@ -2071,7 +2101,9 @@
           ],
           "displayMode": "table",
           "placement": "right",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "multi",
@@ -2085,7 +2117,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(msteams_connect_msgraph_client_time_sum{namespace=~\"$namespace\"}[5m])) by (method) / sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\"}[5m])) by (method)",
+          "expr": "sum(increase(msteams_connect_msgraph_client_time_sum{namespace=~\"$namespace\",method=~\"$top_msgraph_client_latency\"}[5m])) by (method) / sum(increase(msteams_connect_msgraph_client_time_count{namespace=~\"$namespace\",method=~\"$top_msgraph_client_latency\"}[5m])) by (method)",
           "instant": false,
           "legendFormat": "{{handler}}",
           "range": true,
@@ -2129,6 +2161,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2234,6 +2267,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2282,7 +2316,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 10,
         "x": 0,
         "y": 78
       },
@@ -2328,6 +2362,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2376,8 +2411,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 9,
+        "x": 10,
         "y": 78
       },
       "id": 28,
@@ -2415,6 +2450,73 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 78
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_processed_change_event_total{namespace=\"$namespace\",discarded_reason!=\"\"}[15m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "% Events Processed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2422,6 +2524,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2470,7 +2573,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 10,
         "x": 0,
         "y": 86
       },
@@ -2516,6 +2619,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2564,8 +2668,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 9,
+        "x": 10,
         "y": 86
       },
       "id": 30,
@@ -2603,6 +2707,73 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 86
+      },
+      "id": 43,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(msteams_connect_events_lifecycle_event_total{namespace=\"$namespace\",discarded_reason=\"\"}[15m])) / sum(rate(msteams_connect_events_lifecycle_event_total{namespace=\"$namespace\",discarded_reason!=\"\"}[15m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "% Events Processed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2610,6 +2781,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2717,6 +2889,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2837,6 +3010,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -2957,6 +3131,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -3077,6 +3252,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -3197,6 +3373,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -3317,6 +3494,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -3426,7 +3604,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3434,483 +3612,484 @@
         "y": 126
       },
       "id": 17,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 9
-          },
-          "id": 18,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\",api_name=~\"$top_plugin_api_count\"}[5m])) by (api_name)",
-              "instant": false,
-              "legendFormat": "{{handler}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Top 10 Plugin API Requests by Count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 9
-          },
-          "id": 19,
-          "options": {
-            "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "sortBy": "Min",
-              "sortDesc": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(mattermost_plugin_api_time_sum{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\",api_name=~\"$top_plugin_api_latency\"}[5m])) by (api_name) / sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\",api_name=~\"$top_plugin_api_latency\"}[5m])) by (api_name)",
-              "instant": false,
-              "legendFormat": "{{handler}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Top 10 Plugin API Requests by Duration",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "Plugin API",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
         "y": 127
       },
-      "id": 10,
-      "panels": [
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
+          "editorMode": "code",
+          "expr": "sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\",api_name=~\"$top_plugin_api_count\"}[5m])) by (api_name)",
+          "instant": false,
+          "legendFormat": "{{handler}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Plugin API Requests by Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "overrides": [
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byRegexp",
-                  "options": "/Total/"
-                },
-                "properties": [
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 10
-                  }
-                ]
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 10
-          },
-          "id": 11,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "go_goroutines{namespace=~\"$namespace\",instance=~\".*:9094\"}",
-              "instant": false,
-              "legendFormat": "{{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum(go_goroutines{namespace=~\"$namespace\",instance=~\".*:9094\"})",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "Total",
-              "range": true,
-              "refId": "B"
-            }
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 127
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "mean"
           ],
-          "title": "Goroutines",
-          "transformations": [
-            {
-              "id": "renameByRegex",
-              "options": {
-                "regex": "(.*):9094",
-                "renamePattern": "$1"
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Min",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(mattermost_plugin_api_time_sum{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\",api_name=~\"$top_plugin_api_latency\"}[5m])) by (api_name) / sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\",api_name=~\"$top_plugin_api_latency\"}[5m])) by (api_name)",
+          "instant": false,
+          "legendFormat": "{{handler}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Plugin API Requests by Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 135
+      },
+      "id": 10,
+      "panels": [],
+      "title": "System Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
-            }
-          ],
-          "type": "timeseries"
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Total/"
+            },
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 10
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 136
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "go_goroutines{namespace=~\"$namespace\",instance=~\".*:9094\"}",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=~\"$namespace\",instance=~\".*:9094\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Goroutines",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*):9094",
+            "renamePattern": "$1"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "overrides": [
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byRegexp",
-                  "options": "/Total/"
-                },
-                "properties": [
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 10
-                  }
-                ]
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 10
-          },
-          "id": 16,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Total/"
             },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\",instance=~\".*:9094\"}",
-              "instant": false,
-              "legendFormat": "{{instance}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Heap Utilization",
-          "transformations": [
-            {
-              "id": "renameByRegex",
-              "options": {
-                "regex": "(.*):9094",
-                "renamePattern": "$1"
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 10
               }
-            }
-          ],
-          "type": "timeseries"
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 136
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\",instance=~\".*:9094\"}",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "title": "System Metrics",
-      "type": "row"
+      "title": "Heap Utilization",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*):9094",
+            "renamePattern": "$1"
+          }
+        }
+      ],
+      "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "5s",
   "schemaVersion": 38,
-  "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
           "selected": false,
-          "text": "",
-          "value": ""
+          "text": "w1343szyubdr7rkwouxwwjt89c",
+          "value": "w1343szyubdr7rkwouxwwjt89c"
         },
         "description": "The namespace (installation ID) by which to filter the graphs.",
         "hide": 0,
@@ -3919,11 +4098,11 @@
         "options": [
           {
             "selected": true,
-            "text": "",
-            "value": ""
+            "text": "w1343szyubdr7rkwouxwwjt89c",
+            "value": "w1343szyubdr7rkwouxwwjt89c"
           }
         ],
-        "query": "",
+        "query": "w1343szyubdr7rkwouxwwjt89c",
         "skipUrlSync": false,
         "type": "textbox"
       },
@@ -3942,7 +4121,7 @@
           "uid": "${datasource}"
         },
         "definition": "query_result(topk(10, sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\"}[${__range_s}s])) by (api_name)))",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "top_plugin_api_count",
@@ -3972,7 +4151,7 @@
           "uid": "${datasource}"
         },
         "definition": "query_result(topk(10, sum(increase(mattermost_plugin_api_time_sum{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\"}[${__range_s}s])) by (api_name) / sum(increase(mattermost_plugin_api_time_count{namespace=~\"$namespace\",plugin_id=\"com.mattermost.msteams-sync\"}[${__range_s}s])) by (api_name)))",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "top_plugin_api_latency",
@@ -4021,7 +4200,7 @@
           "uid": "${datasource}"
         },
         "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "top_db_count",
@@ -4051,7 +4230,7 @@
           "uid": "${datasource}"
         },
         "definition": "query_result(topk(10, sum(increase(msteams_connect_db_store_time_sum{namespace=\"$namespace\"}[${__range_s}s])) by (method) / sum(increase(msteams_connect_db_store_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "top_db_latency",
@@ -4061,6 +4240,68 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
+        "regex": ".*method=\"(.*?)\".*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "description": "",
+        "hide": 2,
+        "includeAll": true,
+        "multi": true,
+        "name": "top_msgraph_client_count",
+        "options": [],
+        "query": {
+          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": ".*method=\"(.*?)\".*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+        "description": "",
+        "hide": 2,
+        "includeAll": true,
+        "multi": true,
+        "name": "top_msgraph_client_latency",
+        "options": [],
+        "query": {
+          "query": "query_result(topk(10, sum(increase(msteams_connect_msgraph_client_time_count{namespace=\"$namespace\"}[${__range_s}s])) by (method)))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
         "regex": ".*method=\"(.*?)\".*",
         "skipUrlSync": false,
         "sort": 0,
@@ -4076,6 +4317,6 @@
   "timezone": "",
   "title": "MSTeams Connect",
   "uid": "c39b4ded-2384-4775-8e7a-5456fb65fecf",
-  "version": 5,
+  "version": 10,
   "weekStart": ""
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -280,11 +280,6 @@ func (p *Plugin) stop(isRestart bool) {
 	if p.monitor != nil {
 		p.monitor.Stop()
 	}
-	if p.metricsServer != nil {
-		if err := p.metricsServer.Shutdown(); err != nil {
-			p.API.LogWarn("Error shutting down metrics server", "error", err)
-		}
-	}
 	if p.stopSubscriptions != nil {
 		p.stopSubscriptions()
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
#### Summary
Revert https://github.com/mattermost/mattermost-plugin-msteams-sync/pull/439, as it's incorrect to `.Shutdown()` and try to `.ServeAndListen()` on the same `http.Server`. Whenever the server configuration changes, we `reset()` and effectively kill the metrics server. In the past, we completely reset the `http.Server` on `reset()`, so it wasn't an issue, but with the new `ServeMetrics` hook, we (currently) keep around `handler` for reuse there.

Since all of this is going away once we can switch over exclusively to `ServeMetrics` in v1.6.0, ignore the fact that the revert means we no longer respond to configuration changes re: metrics. It's not an issue where we currently intend to deploy the plugin, and won't be an issue for long.

While I'm in here, update the `cloud.json` dashboard snapshot to reflect the renamed metrics.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-56364
