### PR TITLE
build only linux* but support devs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,6 @@ ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
 else
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-linux-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-linux-arm64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-darwin-amd64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-darwin-arm64;
-	cd server && env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-windows-amd64.exe;
 endif
 endif
 

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -59,6 +61,14 @@ func main() {
 	manifest, err := findManifest()
 	if err != nil {
 		panic("failed to find manifest: " + err.Error())
+	}
+
+	if manifest.HasServer() {
+		// Build only the current platform if MM_SERVICESETTINGS_ENABLEDEVELOPER is set.
+		if isDeveloperBuild, _ := strconv.ParseBool(os.Getenv("MM_SERVICESETTINGS_ENABLEDEVELOPER")); isDeveloperBuild {
+			manifest.Server.Executables = nil
+			manifest.Server.Executable = fmt.Sprintf("server/dist/plugin-%s-%s", runtime.GOOS, runtime.GOARCH)
+		}
 	}
 
 	cmd := os.Args[1]

--- a/plugin.json
+++ b/plugin.json
@@ -9,10 +9,7 @@
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",
-            "linux-arm64": "server/dist/plugin-linux-arm64",
-            "darwin-amd64": "server/dist/plugin-darwin-amd64",
-            "darwin-arm64": "server/dist/plugin-darwin-arm64",
-            "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+            "linux-arm64": "server/dist/plugin-linux-arm64"
         }
     },
     "webapp": {


### PR DESCRIPTION
#### Summary
Copy the changes from https://github.com/mattermost/mattermost-plugin-calls/pull/597 to slim down to just building `plugin-linux-amd64` and `plugin-linux-arm64` while still allowing developers to build for an arbitrary local platform when `MM_SERVICESETTINGS_ENABLEDEVELOPER` is true.

This will slim down the releases and make it easier to upload to test servers without bumping the max upload size.

#### Ticket Link
None.