### PR TITLE
initialize API only once

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -914,7 +914,6 @@ func TestConnect(t *testing.T) {
 			}
 
 			mockAPI := &plugintest.API{}
-			mockAPI.On("GetBundlePath").Return("./dist", nil).Once()
 			plugin.SetAPI(mockAPI)
 
 			defer mockAPI.AssertExpectations(t)
@@ -1009,7 +1008,6 @@ func TestGetConnectedUsers(t *testing.T) {
 			mockAPI := &plugintest.API{}
 
 			plugin.SetAPI(mockAPI)
-			mockAPI.On("GetBundlePath").Return("./dist", nil).Once()
 			defer mockAPI.AssertExpectations(t)
 
 			test.SetupPlugin(mockAPI)
@@ -1100,7 +1098,6 @@ func TestGetConnectedUsersFile(t *testing.T) {
 			}
 
 			mockAPI := &plugintest.API{}
-			mockAPI.On("GetBundlePath").Return("./dist", nil).Once()
 			plugin.SetAPI(mockAPI)
 
 			defer mockAPI.AssertExpectations(t)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -74,6 +74,7 @@ type Plugin struct {
 	whitelistClusterMutex     *cluster.Mutex
 	monitor                   *monitor.Monitor
 	syncUserJob               *cluster.Job
+	apiHandler                *API
 
 	activityHandler *handlers.ActivityHandler
 
@@ -83,8 +84,7 @@ type Plugin struct {
 }
 
 func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	api := NewAPI(p, p.store)
-	api.ServeHTTP(w, r)
+	p.apiHandler.ServeHTTP(w, r)
 }
 
 func (p *Plugin) ServeMetrics(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
@@ -410,6 +410,8 @@ func (p *Plugin) OnActivate() error {
 			return err
 		}
 	}
+
+	p.apiHandler = NewAPI(p, p.store)
 
 	if err := p.validateConfiguration(p.getConfiguration()); err != nil {
 		return err

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -69,7 +69,7 @@ func newTestPlugin(t *testing.T) *Plugin {
 	config.SetDefaults()
 	plugin.API.(*plugintest.API).On("KVGet", "cron_monitoring_system").Return(nil, nil).Times(1)
 	plugin.API.(*plugintest.API).On("GetServerVersion").Return("7.8.0")
-	plugin.API.(*plugintest.API).On("GetBundlePath").Return("./dist", nil)
+	plugin.API.(*plugintest.API).On("GetBundlePath").Return("./dist", nil).Maybe()
 	plugin.API.(*plugintest.API).On("Conn", true).Return("connection-id", nil)
 	plugin.API.(*plugintest.API).On("GetUnsanitizedConfig").Return(&config)
 	plugin.API.(*plugintest.API).On("EnsureBotUser", bot).Return("bot-user-id", nil).Times(1)
@@ -92,6 +92,10 @@ func newTestPlugin(t *testing.T) *Plugin {
 
 	plugin.API.(*plugintest.API).Test(t)
 	_ = plugin.OnActivate()
+	// OnActivate is actually failing right now, but mocking it is quite difficult. So just
+	// manually wire up the API by hand until we get the E2E tests going.
+	plugin.apiHandler = NewAPI(plugin, plugin.store)
+
 	plugin.metricsService = mockMetricsService
 	plugin.userID = "bot-user-id"
 	return plugin


### PR DESCRIPTION
#### Summary
Don't initialize the API on every single HTTP request. Besides the performance overhead, this is spamming the plugin API to `GetBundlePath` after upgrading to v1.5.3.:

![image](https://github.com/mattermost/mattermost-plugin-msteams-sync/assets/1023171/eb1ca0cd-3886-475e-b919-40bbd91177ec)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-55489
