### PR TITLE
Better error msg on test fail

### DIFF
--- a/server/ce2e/iframe_test.go
+++ b/server/ce2e/iframe_test.go
@@ -27,8 +27,9 @@ func TestIFrame(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("iframe tab", func(t *testing.T) {
-		resp, err := client.DoAPIRequest(context.Background(), http.MethodGet, client.URL+"/plugins/com.mattermost.msteams-sync/iframe/mattermostTab", "", "")
-		require.NoError(t, err)
+		reqURL := client.URL + "/plugins/com.mattermost.msteams-sync/iframe/mattermostTab"
+		resp, err := client.DoAPIRequest(context.Background(), http.MethodGet, reqURL, "", "")
+		require.NoError(t, err, "cannot fetch url %s", reqURL)
 		defer resp.Body.Close()
 
 		bodyBytes, err := io.ReadAll(resp.Body)
@@ -44,8 +45,9 @@ func TestIFrame(t *testing.T) {
 	})
 
 	t.Run("iframe manifest", func(t *testing.T) {
-		resp, err := client.DoAPIRequest(context.Background(), http.MethodGet, client.URL+"/plugins/com.mattermost.msteams-sync/iframe-manifest", "", "")
-		require.NoError(t, err)
+		reqURL := client.URL + "/plugins/com.mattermost.msteams-sync/iframe-manifest"
+		resp, err := client.DoAPIRequest(context.Background(), http.MethodGet, reqURL, "", "")
+		require.NoError(t, err, "cannot fetch url %s", reqURL)
 		defer resp.Body.Close()
 
 		bodyBytes, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
#### Summary
Enhances error message when ce2e test fails for fetching iframe files.

There was a set of [PRs failing](https://github.com/mattermost/mattermost-plugin-msteams-sync/actions/runs/7586270513/job/20664036753?pr=461) but the error was simply HTTP 404.  This PR adds the url used to ensure the domain, port, etc are correct.

#### Ticket Link
NONE