### PR TITLE
Fixing issue on reconnect required notification

### DIFF
--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -123,7 +123,7 @@ type ChatMessageAttachment struct {
 }
 
 func (e *GraphAPIError) Error() string {
-	return fmt.Sprintf("code: %s, message: %s", e.Code, e.Message)
+	return fmt.Sprintf("code: %s, status_code: %d, message: %s", e.Code, e.StatusCode, e.Message)
 }
 
 func IsOAuthError(err error) bool {

--- a/server/msteams/client_disconnectionlayer/disconnectionlayer.go
+++ b/server/msteams/client_disconnectionlayer/disconnectionlayer.go
@@ -29,7 +29,7 @@ func (c *ClientDisconnectionLayer) Connect() error {
 	err := c.Client.Connect()
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -40,7 +40,7 @@ func (c *ClientDisconnectionLayer) CreateOrGetChatForUsers(usersIDs []string) (*
 	result, err := c.Client.CreateOrGetChatForUsers(usersIDs)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -51,7 +51,7 @@ func (c *ClientDisconnectionLayer) DeleteChatMessage(chatID string, msgID string
 	err := c.Client.DeleteChatMessage(chatID, msgID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -62,7 +62,7 @@ func (c *ClientDisconnectionLayer) DeleteMessage(teamID string, channelID string
 	err := c.Client.DeleteMessage(teamID, channelID, parentID, msgID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -73,7 +73,7 @@ func (c *ClientDisconnectionLayer) DeleteSubscription(subscriptionID string) err
 	err := c.Client.DeleteSubscription(subscriptionID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -84,7 +84,7 @@ func (c *ClientDisconnectionLayer) GetChannelInTeam(teamID string, channelID str
 	result, err := c.Client.GetChannelInTeam(teamID, channelID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -95,7 +95,7 @@ func (c *ClientDisconnectionLayer) GetChannelsInTeam(teamID string, filterQuery 
 	result, err := c.Client.GetChannelsInTeam(teamID, filterQuery)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -106,7 +106,7 @@ func (c *ClientDisconnectionLayer) GetChat(chatID string) (*clientmodels.Chat, e
 	result, err := c.Client.GetChat(chatID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -117,7 +117,7 @@ func (c *ClientDisconnectionLayer) GetChatMessage(chatID string, messageID strin
 	result, err := c.Client.GetChatMessage(chatID, messageID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -128,7 +128,7 @@ func (c *ClientDisconnectionLayer) GetCodeSnippet(url string) (string, error) {
 	result, err := c.Client.GetCodeSnippet(url)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -139,7 +139,7 @@ func (c *ClientDisconnectionLayer) GetFileContent(downloadURL string) ([]byte, e
 	result, err := c.Client.GetFileContent(downloadURL)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -150,7 +150,7 @@ func (c *ClientDisconnectionLayer) GetFileSizeAndDownloadURL(weburl string) (int
 	result, resultVar1, err := c.Client.GetFileSizeAndDownloadURL(weburl)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -161,7 +161,7 @@ func (c *ClientDisconnectionLayer) GetHostedFileContent(activityIDs *clientmodel
 	result, err := c.Client.GetHostedFileContent(activityIDs)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -172,7 +172,7 @@ func (c *ClientDisconnectionLayer) GetMe() (*clientmodels.User, error) {
 	result, err := c.Client.GetMe()
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -183,7 +183,7 @@ func (c *ClientDisconnectionLayer) GetMessage(teamID string, channelID string, m
 	result, err := c.Client.GetMessage(teamID, channelID, messageID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -194,7 +194,7 @@ func (c *ClientDisconnectionLayer) GetMyID() (string, error) {
 	result, err := c.Client.GetMyID()
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -205,7 +205,7 @@ func (c *ClientDisconnectionLayer) GetReply(teamID string, channelID string, mes
 	result, err := c.Client.GetReply(teamID, channelID, messageID, replyID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -216,7 +216,7 @@ func (c *ClientDisconnectionLayer) GetTeam(teamID string) (*clientmodels.Team, e
 	result, err := c.Client.GetTeam(teamID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -227,7 +227,7 @@ func (c *ClientDisconnectionLayer) GetTeams(filterQuery string) ([]*clientmodels
 	result, err := c.Client.GetTeams(filterQuery)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -238,7 +238,7 @@ func (c *ClientDisconnectionLayer) GetUser(userID string) (*clientmodels.User, e
 	result, err := c.Client.GetUser(userID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -249,7 +249,7 @@ func (c *ClientDisconnectionLayer) GetUserAvatar(userID string) ([]byte, error) 
 	result, err := c.Client.GetUserAvatar(userID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -260,7 +260,7 @@ func (c *ClientDisconnectionLayer) ListChannelMessages(teamID string, channelID 
 	result, err := c.Client.ListChannelMessages(teamID, channelID, since)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -271,7 +271,7 @@ func (c *ClientDisconnectionLayer) ListChannels(teamID string) ([]clientmodels.C
 	result, err := c.Client.ListChannels(teamID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -282,7 +282,7 @@ func (c *ClientDisconnectionLayer) ListChatMessages(chatID string, since time.Ti
 	result, err := c.Client.ListChatMessages(chatID, since)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -293,7 +293,7 @@ func (c *ClientDisconnectionLayer) ListSubscriptions() ([]*clientmodels.Subscrip
 	result, err := c.Client.ListSubscriptions()
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -304,7 +304,7 @@ func (c *ClientDisconnectionLayer) ListTeams() ([]clientmodels.Team, error) {
 	result, err := c.Client.ListTeams()
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -315,7 +315,7 @@ func (c *ClientDisconnectionLayer) ListUsers() ([]clientmodels.User, error) {
 	result, err := c.Client.ListUsers()
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -326,7 +326,7 @@ func (c *ClientDisconnectionLayer) RefreshSubscription(subscriptionID string) (*
 	result, err := c.Client.RefreshSubscription(subscriptionID)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -337,7 +337,7 @@ func (c *ClientDisconnectionLayer) RefreshToken(token *oauth2.Token) (*oauth2.To
 	result, err := c.Client.RefreshToken(token)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -348,7 +348,7 @@ func (c *ClientDisconnectionLayer) SendChat(chatID string, message string, paren
 	result, err := c.Client.SendChat(chatID, message, parentMessage, attachments, mentions)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -359,7 +359,7 @@ func (c *ClientDisconnectionLayer) SendMessage(teamID string, channelID string, 
 	result, err := c.Client.SendMessage(teamID, channelID, parentID, message)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -370,7 +370,7 @@ func (c *ClientDisconnectionLayer) SendMessageWithAttachments(teamID string, cha
 	result, err := c.Client.SendMessageWithAttachments(teamID, channelID, parentID, message, attachments, mentions)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -381,7 +381,7 @@ func (c *ClientDisconnectionLayer) SetChatReaction(chatID string, messageID stri
 	result, err := c.Client.SetChatReaction(chatID, messageID, userID, emoji)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -392,7 +392,7 @@ func (c *ClientDisconnectionLayer) SetReaction(teamID string, channelID string, 
 	result, err := c.Client.SetReaction(teamID, channelID, parentID, messageID, userID, emoji)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -403,7 +403,7 @@ func (c *ClientDisconnectionLayer) SubscribeToChannel(teamID string, channelID s
 	result, err := c.Client.SubscribeToChannel(teamID, channelID, baseURL, webhookSecret, certificate)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -414,7 +414,7 @@ func (c *ClientDisconnectionLayer) SubscribeToChannels(baseURL string, webhookSe
 	result, err := c.Client.SubscribeToChannels(baseURL, webhookSecret, pay, certificate)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -425,7 +425,7 @@ func (c *ClientDisconnectionLayer) SubscribeToChats(baseURL string, webhookSecre
 	result, err := c.Client.SubscribeToChats(baseURL, webhookSecret, pay, certificate)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -436,7 +436,7 @@ func (c *ClientDisconnectionLayer) SubscribeToUserChats(user string, baseURL str
 	result, err := c.Client.SubscribeToUserChats(user, baseURL, webhookSecret, pay, certificate)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -447,7 +447,7 @@ func (c *ClientDisconnectionLayer) UnsetChatReaction(chatID string, messageID st
 	result, err := c.Client.UnsetChatReaction(chatID, messageID, userID, emoji)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -458,7 +458,7 @@ func (c *ClientDisconnectionLayer) UnsetReaction(teamID string, channelID string
 	result, err := c.Client.UnsetReaction(teamID, channelID, parentID, messageID, userID, emoji)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -469,7 +469,7 @@ func (c *ClientDisconnectionLayer) UpdateChatMessage(chatID string, msgID string
 	result, err := c.Client.UpdateChatMessage(chatID, msgID, message, mentions)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -480,7 +480,7 @@ func (c *ClientDisconnectionLayer) UpdateMessage(teamID string, channelID string
 	result, err := c.Client.UpdateMessage(teamID, channelID, parentID, msgID, message, mentions)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}
@@ -491,7 +491,7 @@ func (c *ClientDisconnectionLayer) UploadFile(teamID string, channelID string, f
 	result, err := c.Client.UploadFile(teamID, channelID, filename, filesize, mimeType, data, chat)
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}

--- a/server/msteams/layer_generators/disconnection_layer.go.tmpl
+++ b/server/msteams/layer_generators/disconnection_layer.go.tmpl
@@ -31,7 +31,7 @@ func (c *{{$.Name}}) {{$index}}({{$element.Params | joinParamsWithType}}) {{$ele
 	{{genResultsVars $element.Results false }} := c.Client.{{$index}}({{$element.Params | joinParams}})
 	if err != nil {
 		var graphErr *msteams.GraphAPIError
-		if errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized {
+		if msteams.IsOAuthError(err) || (errors.As(err, &graphErr) && graphErr.StatusCode == http.StatusUnauthorized) {
 			c.onDisconnect(c.userID)
 		}
 	}


### PR DESCRIPTION
This fixes the problem of having not valid sessions for msteams and still not reciving the message for reconnect.

Now the user gets properly notified and the session is removed from the database.