### PR TITLE
MM-56501 Enable/disable automuting when a user connects/disconnects

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
   enable:
     - bodyclose
     - errcheck
-    - gocritic
     - gofmt
     - goimports
     - gosec
@@ -42,6 +41,12 @@ issues:
     - path: server/configuration.go
       linters:
         - unused
+
+    - linters:
+      - revive
+      text: "var-naming|error-naming|exported|increment-decrement|error-strings|if-return|unused-parameter|blank-imports|empty-block"
+      # We need to fix the unused parameter issues and remove the exception.
+
     - path: _test\.go
       linters:
         - bodyclose

--- a/server/api.go
+++ b/server/api.go
@@ -471,6 +471,8 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	a.p.updateAutomutingOnUserConnect(mmUserID)
+
 	bundlePath, err := a.p.API.GetBundlePath()
 	if err != nil {
 		a.p.API.LogWarn("Failed to get bundle path.", "error", err.Error())

--- a/server/api.go
+++ b/server/api.go
@@ -471,7 +471,7 @@ func (a *API) oauthRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.p.updateAutomutingOnUserConnect(mmUserID)
+	_, _ = a.p.updateAutomutingOnUserConnect(mmUserID)
 
 	bundlePath, err := a.p.API.GetBundlePath()
 	if err != nil {

--- a/server/automute.go
+++ b/server/automute.go
@@ -126,15 +126,15 @@ func (p *Plugin) setAutomuteIsEnabledForUser(userID string, channelsAutomuted bo
 	return nil
 }
 
-// func (p *Plugin) isUsersPrimaryPlatformTeams(userID string) bool {
-// 	pref, appErr := p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, PreferenceNamePlatform)
-// 	if appErr != nil {
-// 		// GetPreferenceForUser returns an error when a preference is unset, so we default to MM being primary platform
-// 		return false
-// 	}
+func (p *Plugin) isUsersPrimaryPlatformTeams(userID string) bool {
+	pref, appErr := p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, PreferenceNamePlatform)
+	if appErr != nil && errors.Is(appErr.Unwrap(), sql.ErrNoRows) {
+		// GetPreferenceForUser returns an error when a preference is unset, so we default to MM being primary platform
+		return false
+	}
 
-// 	return pref.Value == PreferenceValuePlatformMSTeams
-// }
+	return pref.Value == PreferenceValuePlatformMSTeams
+}
 
 func (p *Plugin) isUserConnected(userID string) (bool, error) {
 	token, err := p.store.GetTokenForMattermostUser(userID)

--- a/server/automute.go
+++ b/server/automute.go
@@ -128,7 +128,7 @@ func (p *Plugin) setAutomuteIsEnabledForUser(userID string, channelsAutomuted bo
 
 func (p *Plugin) isUsersPrimaryPlatformTeams(userID string) bool {
 	pref, appErr := p.API.GetPreferenceForUser(userID, PreferenceCategoryPlugin, PreferenceNamePlatform)
-	if appErr != nil && errors.Is(appErr.Unwrap(), sql.ErrNoRows) {
+	if appErr != nil {
 		// GetPreferenceForUser returns an error when a preference is unset, so we default to MM being primary platform
 		return false
 	}

--- a/server/automute.go
+++ b/server/automute.go
@@ -145,17 +145,6 @@ func (p *Plugin) isUserConnected(userID string) (bool, error) {
 	return token != nil, nil
 }
 
-// // canAutomuteChannelID returns true if the channel with the given ID is either explicitly linked to a channel in
-// // MS Teams or if it's a DM/GM channel that is implicitly linked to MS Teams.
-// func (p *Plugin) canAutomuteChannelID(channelID string) (bool, error) {
-// 	channel, appErr := p.API.GetChannel(channelID)
-// 	if appErr != nil {
-// 		return false, errors.Wrap(appErr, fmt.Sprintf("Unable to get channel %s to check if it's a DM/GM channel", channelID))
-// 	}
-
-// 	return p.canAutomuteChannel(channel)
-// }
-
 // canAutomuteChannel returns true if the channel is either explicitly linked to a channel in MS Teams or if it's a
 // DM/GM channel that is implicitly linked to MS Teams.
 func (p *Plugin) canAutomuteChannel(channel *model.Channel) (bool, error) {

--- a/server/automute.go
+++ b/server/automute.go
@@ -145,6 +145,17 @@ func (p *Plugin) isUserConnected(userID string) (bool, error) {
 	return token != nil, nil
 }
 
+// canAutomuteChannelID returns true if the channel is either explicitly linked to a channel in MS Teams or if it's a
+// DM/GM channel that is implicitly linked to MS Teams.
+func (p *Plugin) canAutomuteChannelID(channelID string) (bool, error) {
+	channel, err := p.API.GetChannel(channelID)
+	if err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf("Unable to get channel %s to determine if it can be automuted", channelID))
+	}
+
+	return p.canAutomuteChannel(channel)
+}
+
 // canAutomuteChannel returns true if the channel is either explicitly linked to a channel in MS Teams or if it's a
 // DM/GM channel that is implicitly linked to MS Teams.
 func (p *Plugin) canAutomuteChannel(channel *model.Channel) (bool, error) {
@@ -153,14 +164,9 @@ func (p *Plugin) canAutomuteChannel(channel *model.Channel) (bool, error) {
 		return true, nil
 	}
 
-	return p.isChannelLinked(channel.Id)
-}
-
-// isChannelLinked returns true if the channel is explicitly linked to a channel in MS Teams.
-func (p *Plugin) isChannelLinked(channelID string) (bool, error) {
-	link, err := p.store.GetLinkByChannelID(channelID)
+	link, err := p.store.GetLinkByChannelID(channel.Id)
 	if err != nil && err != sql.ErrNoRows {
-		return false, errors.Wrap(err, fmt.Sprintf("Unable to determine if channel %s is linked to MS Teams", channelID))
+		return false, errors.Wrap(err, fmt.Sprintf("Unable to determine if channel %s is linked to MS Teams", channel.Id))
 	}
 
 	// The channel is linked as long as a ChannelLink exists

--- a/server/automute.go
+++ b/server/automute.go
@@ -160,7 +160,7 @@ func (p *Plugin) isUserConnected(userID string) (bool, error) {
 // DM/GM channel that is implicitly linked to MS Teams.
 func (p *Plugin) canAutomuteChannel(channel *model.Channel) (bool, error) {
 	// Automute all DM/GM channels
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+	if channel.IsGroupOrDirect() {
 		return true, nil
 	}
 

--- a/server/automute_channel.go
+++ b/server/automute_channel.go
@@ -21,9 +21,9 @@ func (p *Plugin) updateAutomutingOnUserJoinedChannel(c *plugin.Context, userID s
 	if canAutomute, err := p.canAutomuteChannelID(channelID); err != nil {
 		p.API.LogError(
 			"Unable to check if channel is linked to update automuting when a user has joined the channel",
-			"UserID", userID,
-			"ChannelID", channelID,
-			"Error", err.Error(),
+			"user_id", userID,
+			"channel_id", channelID,
+			"error", err.Error(),
 		)
 		return false, errors.Wrap(err, "Unable to update automuting when a user has joined a channel")
 	} else if !canAutomute {
@@ -66,7 +66,7 @@ func (p *Plugin) updateAutomutingForChannelMembers(channelID string, enableAutom
 	page := 0
 	perPage := 200
 	for {
-		members, appErr := p.API.GetChannelMembers(channelID, page, 200)
+		members, appErr := p.API.GetChannelMembers(channelID, page, perPage)
 		if appErr != nil {
 			return errors.Wrap(appErr, fmt.Sprintf("Unable to get all members of channel %s to update automuting", channelID))
 		}

--- a/server/automute_channel.go
+++ b/server/automute_channel.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
+	// TODO MM-56498
+}

--- a/server/automute_channel.go
+++ b/server/automute_channel.go
@@ -18,7 +18,7 @@ func (p *Plugin) updateAutomutingOnUserJoinedChannel(c *plugin.Context, userID s
 		return false, nil
 	}
 
-	if canAutomute, err := p.isChannelLinked(channelID); err != nil {
+	if canAutomute, err := p.canAutomuteChannelID(channelID); err != nil {
 		p.API.LogError(
 			"Unable to check if channel is linked to update automuting when a user has joined the channel",
 			"UserID", userID,

--- a/server/automute_channel.go
+++ b/server/automute_channel.go
@@ -8,3 +8,7 @@ import (
 func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
 	// TODO MM-56498
 }
+
+func (p *Plugin) ChannelHasBeenCreated(c *plugin.Context, channel *model.Channel) {
+	// TODO MM-56499
+}

--- a/server/automute_channel.go
+++ b/server/automute_channel.go
@@ -3,10 +3,34 @@ package main
 import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/pkg/errors"
 )
 
 func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
-	// TODO MM-56498
+	_, _ = p.updateAutomutingOnUserJoinedChannel(c, channelMember.UserId, channelMember.ChannelId)
+}
+
+func (p *Plugin) updateAutomutingOnUserJoinedChannel(c *plugin.Context, userID string, channelID string) (bool, error) {
+	if automuteEnabled := p.getAutomuteIsEnabledForUser(userID); !automuteEnabled {
+		return false, nil
+	}
+
+	if canAutomute, err := p.isChannelLinked(channelID); err != nil {
+		p.API.LogError(
+			"Unable to check if channel is linked to update automuting when a user has joined the channel",
+			"UserID", userID,
+			"ChannelID", channelID,
+			"Error", err.Error(),
+		)
+		return false, errors.Wrap(err, "Unable to update automuting when a user has joined a channel")
+	} else if !canAutomute {
+		// Only automute channels that are linked
+		return false, nil
+	}
+
+	err := p.setChannelMembersAutomuted([]*model.ChannelMemberIdentifier{{UserId: userID, ChannelId: channelID}}, true)
+	return err == nil, err
 }
 
 func (p *Plugin) ChannelHasBeenCreated(c *plugin.Context, channel *model.Channel) {

--- a/server/automute_channel_test.go
+++ b/server/automute_channel_test.go
@@ -300,10 +300,11 @@ func TestUpdateAutomutingOnChannelLinked(t *testing.T) {
 		t.Run("when a channel is linked, "+name, func(t *testing.T) {
 			p := newAutomuteTestPlugin(t)
 
-			channel := &model.Channel{
+			channel, appErr := p.API.CreateChannel(&model.Channel{
 				Id:   model.NewId(),
 				Type: model.ChannelTypeOpen,
-			}
+			})
+			require.Nil(t, appErr)
 
 			mockUnlinkedChannel(p, channel)
 
@@ -320,7 +321,7 @@ func TestUpdateAutomutingOnChannelLinked(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, user.Id)
+			_, appErr = p.API.AddUserToChannel(channel.Id, user.Id, user.Id)
 			require.Nil(t, appErr)
 
 			if testCase.manuallyMuted {
@@ -424,10 +425,11 @@ func TestUpdateAutomutingOnChannelUnlinked(t *testing.T) {
 		t.Run("when a channel is unlinked, "+name, func(t *testing.T) {
 			p := newAutomuteTestPlugin(t)
 
-			channel := &model.Channel{
+			channel, appErr := p.API.CreateChannel(&model.Channel{
 				Id:   model.NewId(),
 				Type: model.ChannelTypeOpen,
-			}
+			})
+			require.Nil(t, appErr)
 
 			mockLinkedChannel(p, channel)
 
@@ -444,7 +446,7 @@ func TestUpdateAutomutingOnChannelUnlinked(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, user.Id)
+			_, appErr = p.API.AddUserToChannel(channel.Id, user.Id, user.Id)
 			require.Nil(t, appErr)
 
 			if testCase.manuallyMuted {

--- a/server/automute_channel_test.go
+++ b/server/automute_channel_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAutomutingOnUserJoinedChannel(t *testing.T) {
+	setup := func(t *testing.T, automuteEnabled bool) (*Plugin, *model.User, *model.Channel, *model.Channel) {
+		t.Helper()
+
+		p := newAutomuteTestPlugin(t)
+
+		user := &model.User{Id: model.NewId()}
+		mockUserConnected(p, user.Id)
+
+		err := p.setAutomuteIsEnabledForUser(user.Id, automuteEnabled)
+		require.NoError(t, err)
+
+		linkedChannel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+		require.Nil(t, appErr)
+		mockLinkedChannel(p, linkedChannel)
+
+		unlinkedChannel, appErr := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+		require.Nil(t, appErr)
+		mockUnlinkedChannel(p, unlinkedChannel)
+
+		return p, user, linkedChannel, unlinkedChannel
+	}
+
+	t.Run("when a user with automuting enabled joins a linked channel, the channel should be muted for that user", func(t *testing.T) {
+		p, user, linkedChannel, _ := setup(t, true)
+
+		_, appErr := p.API.AddUserToChannel(linkedChannel.Id, user.Id, user.Id)
+		require.Nil(t, appErr)
+
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			member, appErr := p.API.GetChannelMember(linkedChannel.Id, user.Id)
+			require.Nil(t, appErr)
+
+			assert.Equal(t, model.ChannelMarkUnreadMention, member.NotifyProps[model.MarkUnreadNotifyProp])
+		}, 1*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("when a user without automuting enabled joins a linked channel, nothing should happen", func(t *testing.T) {
+		p, user, linkedChannel, _ := setup(t, false)
+
+		_, appErr := p.API.AddUserToChannel(linkedChannel.Id, user.Id, user.Id)
+		require.Nil(t, appErr)
+
+		member, appErr := p.API.GetChannelMember(linkedChannel.Id, user.Id)
+		require.Nil(t, appErr)
+
+		assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+	})
+
+	t.Run("when a user with automuting enabled joins a non-linked channel, nothing should happen", func(t *testing.T) {
+		p, user, _, unlinkedChannel := setup(t, true)
+
+		_, appErr := p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, user.Id)
+		require.Nil(t, appErr)
+
+		member, appErr := p.API.GetChannelMember(unlinkedChannel.Id, user.Id)
+		require.Nil(t, appErr)
+
+		assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+	})
+
+	t.Run("when a user without automuting enabled joins a non-linked channel, nothing should happen", func(t *testing.T) {
+		p, user, _, unlinkedChannel := setup(t, false)
+
+		_, appErr := p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, user.Id)
+		require.Nil(t, appErr)
+
+		member, appErr := p.API.GetChannelMember(unlinkedChannel.Id, user.Id)
+		require.Nil(t, appErr)
+
+		assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+	})
+
+	t.Run("should do nothing when an unconnected user joins a linked channel", func(t *testing.T) {
+		p, _, linkedChannel, _ := setup(t, true)
+
+		unconnectedUser := &model.User{Id: model.NewId()}
+		mockUserNotConnected(p, unconnectedUser.Id)
+
+		_, appErr := p.API.AddUserToChannel(linkedChannel.Id, unconnectedUser.Id, unconnectedUser.Id)
+		require.Nil(t, appErr)
+
+		member, appErr := p.API.GetChannelMember(linkedChannel.Id, unconnectedUser.Id)
+		require.Nil(t, appErr)
+
+		assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+	})
+
+	t.Run("should do nothing when an unconnected user joins an unlinked channel", func(t *testing.T) {
+		p, _, _, unlinkedChannel := setup(t, true)
+
+		unconnectedUser := &model.User{Id: model.NewId()}
+		mockUserNotConnected(p, unconnectedUser.Id)
+
+		_, appErr := p.API.AddUserToChannel(unlinkedChannel.Id, unconnectedUser.Id, unconnectedUser.Id)
+		require.Nil(t, appErr)
+
+		member, appErr := p.API.GetChannelMember(unlinkedChannel.Id, unconnectedUser.Id)
+		require.Nil(t, appErr)
+
+		assert.Equal(t, model.ChannelMarkUnreadAll, member.NotifyProps[model.MarkUnreadNotifyProp])
+	})
+
+	t.Run("when a user with automuting enabled joins a linked channel, the channel should only be muted for them", func(t *testing.T) {
+		p, user, linkedChannel, _ := setup(t, true)
+
+		connectedUser := &model.User{Id: model.NewId()}
+		mockUserConnected(p, connectedUser.Id)
+		_, appErr := p.API.AddUserToChannel(linkedChannel.Id, connectedUser.Id, connectedUser.Id)
+		require.Nil(t, appErr)
+
+		unconnectedUser := &model.User{Id: model.NewId()}
+		mockUserConnected(p, unconnectedUser.Id)
+		_, appErr = p.API.AddUserToChannel(linkedChannel.Id, unconnectedUser.Id, connectedUser.Id)
+		require.Nil(t, appErr)
+
+		_, appErr = p.API.AddUserToChannel(linkedChannel.Id, user.Id, user.Id)
+		require.Nil(t, appErr)
+
+		time.Sleep(1 * time.Second)
+
+		connectedMember, appErr := p.API.GetChannelMember(linkedChannel.Id, connectedUser.Id)
+		require.Nil(t, appErr)
+		assert.Equal(t, model.ChannelMarkUnreadAll, connectedMember.NotifyProps[model.MarkUnreadNotifyProp])
+
+		unconnectedMember, appErr := p.API.GetChannelMember(linkedChannel.Id, unconnectedUser.Id)
+		require.Nil(t, appErr)
+		assert.Equal(t, model.ChannelMarkUnreadAll, unconnectedMember.NotifyProps[model.MarkUnreadNotifyProp])
+	})
+}

--- a/server/automute_preferences.go
+++ b/server/automute_preferences.go
@@ -14,7 +14,7 @@ func (p *Plugin) updateAutomutingOnPreferencesChanged(c *plugin.Context, prefere
 
 	for _, userID := range userIDsToEnable {
 		if connected, err := p.isUserConnected(userID); err != nil {
-			p.API.LogError(
+			p.API.LogWarn(
 				"Unable to potentially enable automute for user",
 				"user_id", userID,
 				"error", err.Error(),
@@ -24,7 +24,7 @@ func (p *Plugin) updateAutomutingOnPreferencesChanged(c *plugin.Context, prefere
 		}
 
 		if _, err := p.enableAutomute(userID); err != nil {
-			p.API.LogError(
+			p.API.LogWarn(
 				"Unable to mute channels for a user who set their primary platform to Teams",
 				"user_id", userID,
 				"error", err.Error(),
@@ -35,7 +35,7 @@ func (p *Plugin) updateAutomutingOnPreferencesChanged(c *plugin.Context, prefere
 	for _, userID := range userIDsToDisable {
 		_, err := p.disableAutomute(userID)
 		if err != nil {
-			p.API.LogError(
+			p.API.LogWarn(
 				"Unable to unmute channels for a user who set their primary platform to Mattermost",
 				"user_id", userID,
 				"error", err.Error(),

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -55,6 +55,11 @@ func (a *AutomuteAPIMock) UpdatePreferencesForUser(userID string, preferences []
 func (a *AutomuteAPIMock) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	a.t.Helper()
 
+	// This should be called for all channels, but due to MM-56776, it's currently not called for GM channels
+	if channel.Type != model.ChannelTypeGroup {
+		a.plugin.ChannelHasBeenCreated(&plugin.Context{}, channel)
+	}
+
 	a.channels[channel.Id] = channel
 	return channel, nil
 }

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -89,7 +89,8 @@ func (a *AutomuteAPIMock) GetChannel(channelID string) (*model.Channel, *model.A
 
 	channel, ok := a.channels[channelID]
 	if !ok {
-		return nil, &model.AppError{Message: "AutomuteAPIMock: Channel not found"}
+		appErr := &model.AppError{Message: "AutomuteAPIMock: Channel not found"}
+		return nil, appErr.Wrap(errors.Wrap(sql.ErrNoRows, appErr.Message))
 	}
 
 	return channel, nil

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/store/storemodels"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,8 @@ func (a *AutomuteAPIMock) key(parts ...string) string {
 func (a *AutomuteAPIMock) GetPreferenceForUser(userID, category, name string) (model.Preference, *model.AppError) {
 	preference, ok := a.preferences[a.key(userID, category, name)]
 	if !ok {
-		return model.Preference{}, &model.AppError{Message: "Preference not found"}
+		appErr := &model.AppError{Message: "AutomuteAPIMock: Preference not found"}
+		return model.Preference{}, appErr.Wrap(errors.Wrap(sql.ErrNoRows, appErr.Message))
 	}
 	return preference, nil
 }
@@ -90,7 +92,8 @@ func (a *AutomuteAPIMock) GetChannelsForTeamForUser(teamID, userID string, inclu
 func (a *AutomuteAPIMock) GetChannelMember(channelID, userID string) (*model.ChannelMember, *model.AppError) {
 	member, ok := a.channelMembers[a.key(channelID, userID)]
 	if !ok {
-		return nil, &model.AppError{Message: "Channel member not found"}
+		appErr := &model.AppError{Message: "AutomuteAPIMock: Channel member not found"}
+		return nil, appErr.Wrap(errors.Wrap(sql.ErrNoRows, appErr.Message))
 	}
 	return member, nil
 }

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -89,8 +89,7 @@ func (a *AutomuteAPIMock) GetChannel(channelID string) (*model.Channel, *model.A
 
 	channel, ok := a.channels[channelID]
 	if !ok {
-		appErr := &model.AppError{Message: "AutomuteAPIMock: Channel not found"}
-		return nil, appErr.Wrap(errors.Wrap(sql.ErrNoRows, appErr.Message))
+		return nil, &model.AppError{Message: "AutomuteAPIMock: Channel not found"}
 	}
 
 	return channel, nil

--- a/server/automute_test.go
+++ b/server/automute_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/store/storemodels"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,8 +30,7 @@ func (a *AutomuteAPIMock) key(parts ...string) string {
 func (a *AutomuteAPIMock) GetPreferenceForUser(userID, category, name string) (model.Preference, *model.AppError) {
 	preference, ok := a.preferences[a.key(userID, category, name)]
 	if !ok {
-		appErr := &model.AppError{Message: "AutomuteAPIMock: Preference not found"}
-		return model.Preference{}, appErr.Wrap(errors.Wrap(sql.ErrNoRows, appErr.Message))
+		return model.Preference{}, &model.AppError{Message: "Preference not found"}
 	}
 	return preference, nil
 }
@@ -92,8 +90,7 @@ func (a *AutomuteAPIMock) GetChannelsForTeamForUser(teamID, userID string, inclu
 func (a *AutomuteAPIMock) GetChannelMember(channelID, userID string) (*model.ChannelMember, *model.AppError) {
 	member, ok := a.channelMembers[a.key(channelID, userID)]
 	if !ok {
-		appErr := &model.AppError{Message: "AutomuteAPIMock: Channel member not found"}
-		return nil, appErr.Wrap(errors.Wrap(sql.ErrNoRows, appErr.Message))
+		return nil, &model.AppError{Message: "Channel member not found"}
 	}
 	return member, nil
 }

--- a/server/automute_user_connect.go
+++ b/server/automute_user_connect.go
@@ -7,10 +7,10 @@ func (p *Plugin) updateAutomutingOnUserConnect(userID string) (bool, error) {
 
 	automuteEnabled, err := p.enableAutomute(userID)
 	if err != nil {
-		p.API.LogError(
+		p.API.LogWarn(
 			"Unable to enable automuting for user on connect",
-			"UserID", userID,
-			"Error", err,
+			"user_id", userID,
+			"error", err,
 		)
 	} else {
 		var message string
@@ -20,9 +20,9 @@ func (p *Plugin) updateAutomutingOnUserConnect(userID string) (bool, error) {
 			message = "Not enabling automute for user on connect"
 		}
 
-		p.API.LogDebug(
+		p.API.LogInfo(
 			message,
-			"UserID", userID,
+			"user_id", userID,
 		)
 	}
 
@@ -32,24 +32,26 @@ func (p *Plugin) updateAutomutingOnUserConnect(userID string) (bool, error) {
 func (p *Plugin) updateAutomutingOnUserDisconnect(userID string) (bool, error) {
 	automuteDisabled, err := p.disableAutomute(userID)
 	if err != nil {
-		p.API.LogError(
+		p.API.LogWarn(
 			"Unable to disable automuting for user on disconnect",
-			"UserID", userID,
-			"Error", err,
+			"user_id", userID,
+			"error", err,
 		)
-	} else {
-		var message string
-		if automuteDisabled {
-			message = "Disabled automuting for user on disconnect"
-		} else {
-			message = "User disconnected without automuting enabled"
-		}
 
-		p.API.LogDebug(
-			message,
-			"UserID", userID,
-		)
+		return false, err
 	}
+
+	var message string
+	if automuteDisabled {
+		message = "Disabled automuting for user on disconnect"
+	} else {
+		message = "User disconnected without automuting enabled"
+	}
+
+	p.API.LogInfo(
+		message,
+		"user_id", userID,
+	)
 
 	return automuteDisabled, err
 }

--- a/server/automute_user_connect.go
+++ b/server/automute_user_connect.go
@@ -1,0 +1,55 @@
+package main
+
+func (p *Plugin) updateAutomutingOnUserConnect(userID string) (bool, error) {
+	if !p.isUsersPrimaryPlatformTeams(userID) {
+		return false, nil
+	}
+
+	automuteEnabled, err := p.enableAutomute(userID)
+	if err != nil {
+		p.API.LogError(
+			"Unable to enable automuting for user on connect",
+			"UserID", userID,
+			"Error", err,
+		)
+	} else {
+		var message string
+		if automuteEnabled {
+			message = "Enabled automuting for user on connect"
+		} else {
+			message = "Not enabling automute for user on connect"
+		}
+
+		p.API.LogDebug(
+			message,
+			"UserID", userID,
+		)
+	}
+
+	return automuteEnabled, err
+}
+
+func (p *Plugin) updateAutomutingOnUserDisconnect(userID string) (bool, error) {
+	automuteDisabled, err := p.disableAutomute(userID)
+	if err != nil {
+		p.API.LogError(
+			"Unable to disable automuting for user on disconnect",
+			"UserID", userID,
+			"Error", err,
+		)
+	} else {
+		var message string
+		if automuteDisabled {
+			message = "Disabled automuting for user on disconnect"
+		} else {
+			message = "User disconnected without automuting enabled"
+		}
+
+		p.API.LogDebug(
+			message,
+			"UserID", userID,
+		)
+	}
+
+	return automuteDisabled, err
+}

--- a/server/automute_user_connect_test.go
+++ b/server/automute_user_connect_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAutomutingOnUserConnect(t *testing.T) {
+	setup := func(t *testing.T) (*Plugin, *model.User, *model.Channel) {
+		t.Helper()
+
+		p := newAutomuteTestPlugin(t)
+
+		user := &model.User{Id: model.NewId()}
+
+		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+		p.API.AddUserToChannel(channel.Id, user.Id, "")
+		mockLinkedChannel(p, channel)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+
+		return p, user, channel
+	}
+
+	t.Run("should do nothing when a user connects without their primary platform set", func(t *testing.T) {
+		p, user, channel := setup(t)
+
+		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, false, automuteEnabled)
+
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		assert.Equal(t, "", pref.Value)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+	})
+
+	t.Run("should do nothing when a user connects with their primary platform set to MM", func(t *testing.T) {
+		p, user, channel := setup(t)
+
+		p.API.UpdatePreferencesForUser(user.Id, []model.Preference{{
+			UserId:   user.Id,
+			Category: PreferenceCategoryPlugin,
+			Name:     PreferenceNamePlatform,
+			Value:    PreferenceValuePlatformMM,
+		}})
+
+		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, false, automuteEnabled)
+
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		assert.Equal(t, "", pref.Value)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+	})
+
+	t.Run("should enable automute when a user connects with their primary platform set to Teams", func(t *testing.T) {
+		p, user, channel := setup(t)
+
+		p.API.UpdatePreferencesForUser(user.Id, []model.Preference{{
+			UserId:   user.Id,
+			Category: PreferenceCategoryPlugin,
+			Name:     PreferenceNamePlatform,
+			Value:    PreferenceValuePlatformMSTeams,
+		}})
+
+		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, true, automuteEnabled)
+
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		assert.Equal(t, "true", pref.Value)
+
+		assertChannelAutomuted(t, p, channel.Id, user.Id)
+	})
+
+	t.Run("should do nothing if somehow called twice in a row", func(t *testing.T) {
+		p, user, channel := setup(t)
+
+		p.API.UpdatePreferencesForUser(user.Id, []model.Preference{
+			{
+				UserId:   user.Id,
+				Category: PreferenceCategoryPlugin,
+				Name:     PreferenceNamePlatform,
+				Value:    PreferenceValuePlatformMSTeams,
+			},
+			{
+				UserId:   user.Id,
+				Category: PreferenceCategoryPlugin,
+				Name:     PreferenceNameAutomuteEnabled,
+				Value:    "true",
+			},
+		})
+
+		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, false, automuteEnabled)
+
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		assert.Equal(t, "true", pref.Value)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+	})
+}
+
+func TestUpdateAutomutingOnUserDisconnect(t *testing.T) {
+	setup := func(t *testing.T) (*Plugin, *model.User, *model.Channel) {
+		t.Helper()
+
+		p := newAutomuteTestPlugin(t)
+
+		user := &model.User{Id: model.NewId()}
+		mockUserConnected(p, user.Id)
+
+		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+		p.API.AddUserToChannel(channel.Id, user.Id, "")
+		mockLinkedChannel(p, channel)
+
+		return p, user, channel
+	}
+
+	t.Run("should disable automute when a user disconnects who previously had automuting enabled", func(t *testing.T) {
+		p, user, channel := setup(t)
+
+		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
+			{
+				UserId:   user.Id,
+				Category: PreferenceCategoryPlugin,
+				Name:     PreferenceNamePlatform,
+				Value:    PreferenceValuePlatformMSTeams,
+			},
+		})
+
+		// Confirm that the user starts with automute enabled and a muted channel
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		require.Equal(t, "true", pref.Value)
+
+		assertChannelAutomuted(t, p, channel.Id, user.Id)
+
+		// Disconnect
+		automuteDisabled, err := p.updateAutomutingOnUserDisconnect(user.Id)
+
+		require.NoError(t, err)
+		assert.Equal(t, true, automuteDisabled)
+
+		// The user should no longer have automute enabled and the channel should no longer be muted
+		pref, _ = p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		require.Equal(t, "false", pref.Value)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+	})
+
+	t.Run("should do nothing when a user disconnects without automuting enabled", func(t *testing.T) {
+		p, user, channel := setup(t)
+
+		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
+			{
+				UserId:   user.Id,
+				Category: PreferenceCategoryPlugin,
+				Name:     PreferenceNamePlatform,
+				Value:    PreferenceValuePlatformMM,
+			},
+		})
+
+		// Confirm that the user starts with automute enabled and a muted channel
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		require.Equal(t, "", pref.Value)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+
+		// Disconnect
+		automuteDisabled, err := p.updateAutomutingOnUserDisconnect(user.Id)
+
+		require.NoError(t, err)
+		assert.Equal(t, false, automuteDisabled)
+
+		// Confirm nothing changed
+		pref, _ = p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		require.Equal(t, "", pref.Value)
+
+		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
+	})
+
+	t.Run("should not unmute a manually muted unlinked channel when a user disconnects", func(t *testing.T) {
+		p, user, _ := setup(t)
+
+		unlinkedChannel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
+		p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, "")
+		mockUnlinkedChannel(p, unlinkedChannel)
+
+		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{
+			{
+				UserId:   user.Id,
+				Category: PreferenceCategoryPlugin,
+				Name:     PreferenceNamePlatform,
+				Value:    PreferenceValuePlatformMSTeams,
+			},
+		})
+
+		// Confirm that the user starts with automute enabled and the channel is not muted
+		pref, _ := p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		require.Equal(t, "true", pref.Value)
+
+		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
+
+		// Disconnect
+		automuteDisabled, err := p.updateAutomutingOnUserDisconnect(user.Id)
+
+		require.NoError(t, err)
+		assert.Equal(t, true, automuteDisabled)
+
+		// The user should no longer have automute enabled and the channel is still not muted
+		pref, _ = p.API.GetPreferenceForUser(user.Id, PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled)
+		require.Equal(t, "false", pref.Value)
+
+		assertChannelNotAutomuted(t, p, unlinkedChannel.Id, user.Id)
+	})
+}

--- a/server/automute_user_connect_test.go
+++ b/server/automute_user_connect_test.go
@@ -16,6 +16,7 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 		p := newAutomuteTestPlugin(t)
 
 		user := &model.User{Id: model.NewId()}
+		mockUserNotConnected(p, user.Id)
 
 		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
 		_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, "")

--- a/server/automute_user_connect_test.go
+++ b/server/automute_user_connect_test.go
@@ -18,7 +18,8 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 		user := &model.User{Id: model.NewId()}
 
 		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		p.API.AddUserToChannel(channel.Id, user.Id, "")
+		_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, "")
+		require.Nil(t, appErr)
 		mockLinkedChannel(p, channel)
 
 		assertChannelNotAutomuted(t, p, channel.Id, user.Id)
@@ -43,12 +44,13 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 	t.Run("should do nothing when a user connects with their primary platform set to MM", func(t *testing.T) {
 		p, user, channel := setup(t)
 
-		p.API.UpdatePreferencesForUser(user.Id, []model.Preference{{
+		appErr := p.API.UpdatePreferencesForUser(user.Id, []model.Preference{{
 			UserId:   user.Id,
 			Category: PreferenceCategoryPlugin,
 			Name:     PreferenceNamePlatform,
 			Value:    PreferenceValuePlatformMM,
 		}})
+		require.Nil(t, appErr)
 
 		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
 		require.NoError(t, err)
@@ -64,12 +66,13 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 	t.Run("should enable automute when a user connects with their primary platform set to Teams", func(t *testing.T) {
 		p, user, channel := setup(t)
 
-		p.API.UpdatePreferencesForUser(user.Id, []model.Preference{{
+		appErr := p.API.UpdatePreferencesForUser(user.Id, []model.Preference{{
 			UserId:   user.Id,
 			Category: PreferenceCategoryPlugin,
 			Name:     PreferenceNamePlatform,
 			Value:    PreferenceValuePlatformMSTeams,
 		}})
+		require.Nil(t, appErr)
 
 		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
 		require.NoError(t, err)
@@ -85,7 +88,7 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 	t.Run("should do nothing if somehow called twice in a row", func(t *testing.T) {
 		p, user, channel := setup(t)
 
-		p.API.UpdatePreferencesForUser(user.Id, []model.Preference{
+		appErr := p.API.UpdatePreferencesForUser(user.Id, []model.Preference{
 			{
 				UserId:   user.Id,
 				Category: PreferenceCategoryPlugin,
@@ -99,6 +102,7 @@ func TestUpdateAutomutingOnUserConnect(t *testing.T) {
 				Value:    "true",
 			},
 		})
+		require.Nil(t, appErr)
 
 		automuteEnabled, err := p.updateAutomutingOnUserConnect(user.Id)
 		require.NoError(t, err)
@@ -122,7 +126,8 @@ func TestUpdateAutomutingOnUserDisconnect(t *testing.T) {
 		mockUserConnected(p, user.Id)
 
 		channel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		p.API.AddUserToChannel(channel.Id, user.Id, "")
+		_, appErr := p.API.AddUserToChannel(channel.Id, user.Id, "")
+		require.Nil(t, appErr)
 		mockLinkedChannel(p, channel)
 
 		return p, user, channel
@@ -194,7 +199,8 @@ func TestUpdateAutomutingOnUserDisconnect(t *testing.T) {
 		p, user, _ := setup(t)
 
 		unlinkedChannel, _ := p.API.CreateChannel(&model.Channel{Id: model.NewId(), Type: model.ChannelTypeOpen})
-		p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, "")
+		_, appErr := p.API.AddUserToChannel(unlinkedChannel.Id, user.Id, "")
+		require.Nil(t, appErr)
 		mockUnlinkedChannel(p, unlinkedChannel)
 
 		p.PreferencesHaveChanged(&plugin.Context{}, []model.Preference{

--- a/server/command.go
+++ b/server/command.go
@@ -241,6 +241,10 @@ func (p *Plugin) executeLinkCommand(args *model.CommandArgs, parameters []string
 		}
 	}
 
+	if err := p.updateAutomutingOnChannelLinked(args.ChannelId); err != nil {
+		p.API.LogWarn("Unable to automute members when channel becomes linked", "error", err.Error())
+	}
+
 	p.sendBotEphemeralPost(args.UserId, args.ChannelId, "The MS Teams channel is now linked to this Mattermost channel.")
 	return &model.CommandResponse{}, nil
 }
@@ -294,6 +298,10 @@ func (p *Plugin) executeUnlinkCommand(args *model.CommandArgs) (*model.CommandRe
 
 	if err = p.GetClientForApp().DeleteSubscription(subscription.SubscriptionID); err != nil {
 		p.API.LogWarn("Unable to delete the subscription on MS Teams", "subscription_id", subscription.SubscriptionID, "error", err.Error())
+	}
+
+	if err := p.updateAutomutingOnChannelUnlinked(args.ChannelId); err != nil {
+		p.API.LogWarn("Unable to unmute automuted members when channel becomes unlinked", "error", err.Error())
 	}
 
 	return &model.CommandResponse{}, nil

--- a/server/command.go
+++ b/server/command.go
@@ -552,6 +552,8 @@ func (p *Plugin) executeDisconnectCommand(args *model.CommandArgs) (*model.Comma
 		p.API.LogWarn("Unable to delete the last prompt timestamp for the user", "user_id", args.UserId, "error", err.Error())
 	}
 
+	p.updateAutomutingOnUserDisconnect(args.UserId)
+
 	return &model.CommandResponse{}, nil
 }
 

--- a/server/command.go
+++ b/server/command.go
@@ -552,7 +552,7 @@ func (p *Plugin) executeDisconnectCommand(args *model.CommandArgs) (*model.Comma
 		p.API.LogWarn("Unable to delete the last prompt timestamp for the user", "user_id", args.UserId, "error", err.Error())
 	}
 
-	p.updateAutomutingOnUserDisconnect(args.UserId)
+	_, _ = p.updateAutomutingOnUserDisconnect(args.UserId)
 
 	return &model.CommandResponse{}, nil
 }

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -78,6 +78,7 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 				}, nil).Times(1)
 				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", testutils.GetChannelID(), "The MS Teams channel is no longer linked to this Mattermost channel.")).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
+				api.On("GetChannelMembers", testutils.GetChannelID(), 0, 200).Return(model.ChannelMembers(nil), (*model.AppError)(nil)).Times(1)
 				api.On("UnshareChannel", "Valid-MattermostChannelID").Return(true, nil).Once()
 			},
 			setupStore: func(s *mockStore.Store) {
@@ -677,6 +678,7 @@ func TestExecuteLinkCommand(t *testing.T) {
 				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", testutils.GetChannelID(), commandWaitingMessage)).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", testutils.GetChannelID(), "The MS Teams channel is now linked to this Mattermost channel.")).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
+				api.On("GetChannelMembers", testutils.GetChannelID(), 0, 200).Return(model.ChannelMembers(nil), (*model.AppError)(nil)).Times(1)
 				api.On("ShareChannel", mock.AnythingOfType("*model.SharedChannel")).Return(nil, nil).Times(1)
 			},
 			setupStore: func(s *mockStore.Store) {

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -45,6 +45,7 @@ func TestExecuteUnlinkCommand(t *testing.T) {
 				}, nil).Times(1)
 				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", testutils.GetChannelID(), "The MS Teams channel is no longer linked to this Mattermost channel.")).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
+				api.On("GetChannelMembers", testutils.GetChannelID(), 0, 200).Return(model.ChannelMembers(nil), (*model.AppError)(nil)).Times(1)
 			},
 			setupStore: func(s *mockStore.Store) {
 				s.On("GetLinkByChannelID", testutils.GetChannelID()).Return(&storemodels.ChannelLink{
@@ -633,6 +634,7 @@ func TestExecuteLinkCommand(t *testing.T) {
 				api.On("HasPermissionToChannel", testutils.GetUserID(), testutils.GetChannelID(), model.PermissionManageChannelRoles).Return(true).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", testutils.GetChannelID(), commandWaitingMessage)).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", testutils.GetChannelID(), "The MS Teams channel is now linked to this Mattermost channel.")).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
+				api.On("GetChannelMembers", testutils.GetChannelID(), 0, 200).Return(model.ChannelMembers(nil), (*model.AppError)(nil)).Times(1)
 			},
 			setupStore: func(s *mockStore.Store) {
 				s.On("CheckEnabledTeamByTeamID", testutils.GetTeamsUserID()).Return(true).Times(1)

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -461,6 +461,8 @@ func TestExecuteDisconnectCommand(t *testing.T) {
 			},
 			setupAPI: func(api *plugintest.API) {
 				api.On("SendEphemeralPost", testutils.GetUserID(), testutils.GetEphemeralPost("bot-user-id", "", "Your account has been disconnected.")).Return(testutils.GetPost("", testutils.GetUserID(), time.Now().UnixMicro())).Times(1)
+
+				api.On("GetPreferenceForUser", testutils.GetUserID(), PreferenceCategoryPlugin, PreferenceNameAutomuteEnabled).Return(model.Preference{}, &model.AppError{Message: "no preference found"})
 			},
 			setupStore: func(s *mockStore.Store) {
 				s.On("MattermostToTeamsUserID", testutils.GetUserID()).Return(testutils.GetTeamsUserID(), nil).Times(1)


### PR DESCRIPTION
#### Summary
Continuing from https://github.com/mattermost/mattermost-plugin-msteams-sync/pull/477, since automuting is enabled when a user is both connected and has their primary platform set to MS Teams, we need to also potentially enable or disable automuting when a user connects or disconnects from MS Teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56501

