### PR TITLE
Disable reactions / files attachments / linked channels by default

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -81,6 +81,12 @@
           "help_text": "Sync direct and group messages where any of the user in the conversation is a real Mattermost user connected to MS Teams account",
           "default": false
         },{
+          "key": "syncLinkedChannels",
+          "display_name": "Sync linked channels",
+          "type": "bool",
+          "help_text": "Sync messages from channels linked between Matteromst and MS Teams",
+          "default": false
+        },{
           "key": "syncReactions",
           "display_name": "Sync reactions",
           "type": "bool",

--- a/plugin.json
+++ b/plugin.json
@@ -81,6 +81,12 @@
           "help_text": "Sync direct and group messages where any of the user in the conversation is a real Mattermost user connected to MS Teams account",
           "default": false
         },{
+          "key": "syncReactions",
+          "display_name": "Sync reactions",
+          "type": "bool",
+          "help_text": "Sync reactions on messages",
+          "default": false
+        },{
           "key": "enabledTeams",
           "display_name": "Enabled Teams",
           "type": "text",

--- a/plugin.json
+++ b/plugin.json
@@ -84,7 +84,7 @@
           "key": "syncLinkedChannels",
           "display_name": "Sync linked channels",
           "type": "bool",
-          "help_text": "Sync messages from channels linked between Matteromst and MS Teams",
+          "help_text": "Sync messages from channels linked between Mattermost and MS Teams",
           "default": false
         },{
           "key": "syncReactions",

--- a/plugin.json
+++ b/plugin.json
@@ -87,6 +87,12 @@
           "help_text": "Sync reactions on messages",
           "default": false
         },{
+          "key": "syncFileAttachments",
+          "display_name": "Sync file attachments",
+          "type": "bool",
+          "help_text": "Sync file attachments on messages",
+          "default": false
+        },{
           "key": "enabledTeams",
           "display_name": "Enabled Teams",
           "type": "text",

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1002,11 +1002,13 @@ func TestExecuteConnectBotCommand(t *testing.T) {
 
 func TestGetAutocompleteData(t *testing.T) {
 	for _, testCase := range []struct {
-		description      string
-		autocompleteData *model.AutocompleteData
+		description        string
+		syncLinkedChannels bool
+		autocompleteData   *model.AutocompleteData
 	}{
 		{
-			description: "Successfully get all auto complete data",
+			description:        "Successfully get all auto complete data",
+			syncLinkedChannels: true,
 			autocompleteData: &model.AutocompleteData{
 				Trigger:   "msteams-sync",
 				Hint:      "[command]",
@@ -1117,9 +1119,76 @@ func TestGetAutocompleteData(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:        "Successfully get all auto complete data",
+			syncLinkedChannels: false,
+			autocompleteData: &model.AutocompleteData{
+				Trigger:   "msteams-sync",
+				Hint:      "[command]",
+				HelpText:  "Manage MS Teams linked channels",
+				RoleID:    model.SystemUserRoleId,
+				Arguments: []*model.AutocompleteArg{},
+				SubCommands: []*model.AutocompleteData{
+					{
+						Trigger:     "connect",
+						HelpText:    "Connect your Mattermost account to your MS Teams account",
+						RoleID:      model.SystemUserRoleId,
+						Arguments:   []*model.AutocompleteArg{},
+						SubCommands: []*model.AutocompleteData{},
+					},
+					{
+						Trigger:     "disconnect",
+						HelpText:    "Disconnect your Mattermost account from your MS Teams account",
+						RoleID:      model.SystemUserRoleId,
+						Arguments:   []*model.AutocompleteArg{},
+						SubCommands: []*model.AutocompleteData{},
+					},
+					{
+						Trigger:     "connect-bot",
+						HelpText:    "Connect the bot account (only system admins can do this)",
+						RoleID:      model.SystemAdminRoleId,
+						Arguments:   []*model.AutocompleteArg{},
+						SubCommands: []*model.AutocompleteData{},
+					},
+					{
+						Trigger:     "disconnect-bot",
+						HelpText:    "Disconnect the bot account (only system admins can do this)",
+						RoleID:      model.SystemAdminRoleId,
+						Arguments:   []*model.AutocompleteArg{},
+						SubCommands: []*model.AutocompleteData{},
+					},
+					{
+						Trigger:  "promote",
+						HelpText: "Promote a user from synthetic user account to regular mattermost account",
+						RoleID:   model.SystemAdminRoleId,
+						Arguments: []*model.AutocompleteArg{
+							{
+								HelpText: "Username of the existing mattermost user",
+								Type:     "TextInput",
+								Required: true,
+								Data: &model.AutocompleteTextArg{
+									Hint:    "username",
+									Pattern: `^[a-z0-9\.\-_:]+$`,
+								},
+							},
+							{
+								HelpText: "The new username after the user is promoted",
+								Type:     "TextInput",
+								Required: true,
+								Data: &model.AutocompleteTextArg{
+									Hint:    "new username",
+									Pattern: `^[a-z0-9\.\-_:]+$`,
+								},
+							},
+						},
+						SubCommands: []*model.AutocompleteData{},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
-			autocompleteData := getAutocompleteData()
+			autocompleteData := getAutocompleteData(testCase.syncLinkedChannels)
 			assert.Equal(t, testCase.autocompleteData, autocompleteData)
 		})
 	}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,7 @@ type configuration struct {
 	WebhookSecret                      string `json:"webhooksecret"`
 	EnabledTeams                       string `json:"enabledteams"`
 	SyncDirectMessages                 bool   `json:"syncdirectmessages"`
+	SyncReactions                      bool   `json:"syncreactions"`
 	SyncUsers                          int    `json:"syncusers"`
 	SyncGuestUsers                     bool   `json:"syncGuestUsers"`
 	CertificatePublic                  string `json:"certificatepublic"`

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,7 @@ type configuration struct {
 	WebhookSecret                      string `json:"webhooksecret"`
 	EnabledTeams                       string `json:"enabledteams"`
 	SyncDirectMessages                 bool   `json:"syncdirectmessages"`
+	SyncLinkedChannels                 bool   `json:"synclinkedchannels"`
 	SyncReactions                      bool   `json:"syncreactions"`
 	SyncFileAttachments                bool   `json:"syncfileattachments"`
 	SyncUsers                          int    `json:"syncusers"`

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -29,6 +29,7 @@ type configuration struct {
 	EnabledTeams                       string `json:"enabledteams"`
 	SyncDirectMessages                 bool   `json:"syncdirectmessages"`
 	SyncReactions                      bool   `json:"syncreactions"`
+	SyncFileAttachments                bool   `json:"syncfileattachments"`
 	SyncUsers                          int    `json:"syncusers"`
 	SyncGuestUsers                     bool   `json:"syncGuestUsers"`
 	CertificatePublic                  string `json:"certificatepublic"`

--- a/server/handlers/attachments.go
+++ b/server/handlers/attachments.go
@@ -145,6 +145,10 @@ func (ah *ActivityHandler) handleAttachments(channelID, userID, text string, msg
 			continue
 		}
 
+		if !ah.plugin.GetSyncFileAttachments() {
+			continue
+		}
+
 		// handle the download
 		var attachmentData []byte
 		var err error

--- a/server/handlers/attachments_test.go
+++ b/server/handlers/attachments_test.go
@@ -267,8 +267,35 @@ func TestHandleAttachments(t *testing.T) {
 		expectedError              bool
 	}{
 		{
+			description: "File attachments disabled by configuration",
+			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(false).Maybe()
+				p.On("GetClientForApp").Return(client).Maybe()
+				p.On("GetAPI").Return(mockAPI).Maybe()
+				p.On("GetMetrics").Return(mockmetrics).Maybe()
+			},
+			setupAPI: func(mockAPI *plugintest.API) {
+				mockAPI.On("GetConfig").Return(&model.Config{
+					FileSettings: model.FileSettings{
+						MaxFileSize: model.NewInt64(5),
+					},
+				})
+				mockAPI.On("UploadFile", []byte{}, testutils.GetChannelID(), "mock-name").Return(&model.FileInfo{
+					Id: testutils.GetID(),
+				}, nil)
+			},
+			setupClient: func(client *mocksClient.Client) {
+			},
+			setupMetrics: func(mockmetrics *mocksMetrics.Metrics) {
+			},
+			attachments:                []clientmodels.Attachment{},
+			expectedText:               "mock-text",
+			expectedAttachmentIDsCount: 0,
+		},
+		{
 			description: "Successfully handled attachments",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetMaxSizeForCompleteDownload").Return(1).Times(1)
@@ -302,6 +329,7 @@ func TestHandleAttachments(t *testing.T) {
 		{
 			description: "Client is nil",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(true).Maybe()
 				p.On("GetClientForApp").Return(nil)
 				p.On("GetAPI").Return(mockAPI).Maybe()
 			},
@@ -318,6 +346,7 @@ func TestHandleAttachments(t *testing.T) {
 		{
 			description: "Error uploading the file",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetMaxSizeForCompleteDownload").Return(1).Times(1)
@@ -348,6 +377,7 @@ func TestHandleAttachments(t *testing.T) {
 		{
 			description: "Number of attachments are greater than 10",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetMaxSizeForCompleteDownload").Return(1).Times(10)
@@ -378,6 +408,7 @@ func TestHandleAttachments(t *testing.T) {
 		{
 			description: "Attachment type code snippet",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
 			},
@@ -405,6 +436,7 @@ func TestHandleAttachments(t *testing.T) {
 		{
 			description: "Attachment type message reference",
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, client *mocksClient.Client, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncFileAttachments").Return(true).Maybe()
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetStore").Return(store, nil)

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -27,6 +27,7 @@ type pluginMock struct {
 	api                        plugin.API
 	store                      store.Store
 	syncDirectMessages         bool
+	syncLinkedChannels         bool
 	syncReactions              bool
 	syncFileAttachments        bool
 	syncGuestUsers             bool
@@ -42,6 +43,7 @@ type pluginMock struct {
 
 func (pm *pluginMock) GetAPI() plugin.API                              { return pm.api }
 func (pm *pluginMock) GetStore() store.Store                           { return pm.store }
+func (pm *pluginMock) GetSyncLinkedChannels() bool                     { return pm.syncLinkedChannels }
 func (pm *pluginMock) GetSyncDirectMessages() bool                     { return pm.syncDirectMessages }
 func (pm *pluginMock) GetSyncFileAttachments() bool                    { return pm.syncFileAttachments }
 func (pm *pluginMock) GetSyncReactions() bool                          { return pm.syncReactions }

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -28,6 +28,7 @@ type pluginMock struct {
 	store                      store.Store
 	syncDirectMessages         bool
 	syncReactions              bool
+	syncFileAttachments        bool
 	syncGuestUsers             bool
 	maxSizeForCompleteDownload int
 	bufferSizeForStreaming     int
@@ -42,6 +43,7 @@ type pluginMock struct {
 func (pm *pluginMock) GetAPI() plugin.API                              { return pm.api }
 func (pm *pluginMock) GetStore() store.Store                           { return pm.store }
 func (pm *pluginMock) GetSyncDirectMessages() bool                     { return pm.syncDirectMessages }
+func (pm *pluginMock) GetSyncFileAttachments() bool                    { return pm.syncFileAttachments }
 func (pm *pluginMock) GetSyncReactions() bool                          { return pm.syncReactions }
 func (pm *pluginMock) GetSyncGuestUsers() bool                         { return pm.syncGuestUsers }
 func (pm *pluginMock) GetMaxSizeForCompleteDownload() int              { return pm.maxSizeForCompleteDownload }

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -27,6 +27,7 @@ type pluginMock struct {
 	api                        plugin.API
 	store                      store.Store
 	syncDirectMessages         bool
+	syncReactions              bool
 	syncGuestUsers             bool
 	maxSizeForCompleteDownload int
 	bufferSizeForStreaming     int
@@ -41,6 +42,7 @@ type pluginMock struct {
 func (pm *pluginMock) GetAPI() plugin.API                              { return pm.api }
 func (pm *pluginMock) GetStore() store.Store                           { return pm.store }
 func (pm *pluginMock) GetSyncDirectMessages() bool                     { return pm.syncDirectMessages }
+func (pm *pluginMock) GetSyncReactions() bool                          { return pm.syncReactions }
 func (pm *pluginMock) GetSyncGuestUsers() bool                         { return pm.syncGuestUsers }
 func (pm *pluginMock) GetMaxSizeForCompleteDownload() int              { return pm.maxSizeForCompleteDownload }
 func (pm *pluginMock) GetBufferSizeForStreaming() int                  { return pm.bufferSizeForStreaming }

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -38,6 +38,7 @@ type PluginIface interface {
 	GetStore() store.Store
 	GetMetrics() metrics.Metrics
 	GetSyncDirectMessages() bool
+	GetSyncReactions() bool
 	GetSyncGuestUsers() bool
 	GetMaxSizeForCompleteDownload() int
 	GetBufferSizeForStreaming() int
@@ -456,6 +457,10 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, subs
 }
 
 func (ah *ActivityHandler) handleReactions(postID, channelID string, isDirectMessage bool, reactions []clientmodels.Reaction) {
+	if !ah.plugin.GetSyncReactions() {
+		return
+	}
+
 	postReactions, appErr := ah.plugin.GetAPI().GetReactions(postID)
 	if appErr != nil {
 		return

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -38,6 +38,7 @@ type PluginIface interface {
 	GetStore() store.Store
 	GetMetrics() metrics.Metrics
 	GetSyncDirectMessages() bool
+	GetSyncLinkedChannels() bool
 	GetSyncReactions() bool
 	GetSyncFileAttachments() bool
 	GetSyncGuestUsers() bool
@@ -312,6 +313,11 @@ func (ah *ActivityHandler) handleCreatedActivity(msg *clientmodels.Message, subs
 		}
 		senderID, _ = ah.plugin.GetStore().TeamsToMattermostUserID(msg.UserID)
 	} else {
+		if !ah.plugin.GetSyncLinkedChannels() {
+			// Skipping because linked channels are disabled
+			return metrics.DiscardedReasonLinkedChannelsDisabled
+		}
+
 		senderID, _ = ah.getOrCreateSyntheticUser(msteamsUser, true)
 		channelLink, _ := ah.plugin.GetStore().GetLinkByMSTeamsChannelID(msg.TeamID, msg.ChannelID)
 		if channelLink != nil {
@@ -391,6 +397,11 @@ func (ah *ActivityHandler) handleUpdatedActivity(msg *clientmodels.Message, subs
 
 	channelID := ""
 	if chat == nil {
+		if !ah.plugin.GetSyncLinkedChannels() {
+			// Skipping because linked channels are disabled
+			return metrics.DiscardedReasonLinkedChannelsDisabled
+		}
+
 		var channelLink *storemodels.ChannelLink
 		channelLink, err = ah.plugin.GetStore().GetLinkByMSTeamsChannelID(msg.TeamID, msg.ChannelID)
 		if err != nil || channelLink == nil {

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -39,6 +39,7 @@ type PluginIface interface {
 	GetMetrics() metrics.Metrics
 	GetSyncDirectMessages() bool
 	GetSyncReactions() bool
+	GetSyncFileAttachments() bool
 	GetSyncGuestUsers() bool
 	GetMaxSizeForCompleteDownload() int
 	GetBufferSizeForStreaming() int

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -546,6 +546,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				ChatID: "invalid-ChatID",
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 			},
@@ -564,6 +565,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
@@ -591,6 +593,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
 				p.On("GetAPI").Return(mockAPI).Maybe()
@@ -618,6 +621,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
 				p.On("GetAPI").Return(mockAPI).Maybe()
@@ -654,6 +658,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
 				p.On("GetStore").Return(store).Maybe()
@@ -691,6 +696,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
 				p.On("GetAPI").Return(mockAPI).Maybe()
@@ -736,6 +742,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(1)
 				p.On("GetAPI").Return(mockAPI).Maybe()
@@ -784,6 +791,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetClientForTeamsUser", testutils.GetTeamsUserID()).Return(client, nil).Times(2)
 				p.On("GetAPI").Return(mockAPI).Maybe()
@@ -839,6 +847,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				MessageID: testutils.GetMessageID(),
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, client *mocksClient.Client, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Maybe()
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetStore").Return(store).Maybe()
@@ -1006,9 +1015,21 @@ func TestHandleReactions(t *testing.T) {
 		setupMetrics func(*mocksMetrics.Metrics)
 	}{
 		{
+			description: "Disabled by configuration",
+			reactions:   []clientmodels.Reaction{},
+			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(false).Once()
+			},
+			setupAPI: func(mockAPI *plugintest.API) {
+			},
+			setupStore:   func(store *mocksStore.Store) {},
+			setupMetrics: func(mockmetrics *mocksMetrics.Metrics) {},
+		},
+		{
 			description: "Reactions list is empty",
 			reactions:   []clientmodels.Reaction{},
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Once()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
@@ -1026,6 +1047,7 @@ func TestHandleReactions(t *testing.T) {
 				},
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Once()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 			},
 			setupAPI: func(mockAPI *plugintest.API) {
@@ -1043,6 +1065,7 @@ func TestHandleReactions(t *testing.T) {
 				},
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Once()
 				p.On("GetStore").Return(store).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
@@ -1079,6 +1102,7 @@ func TestHandleReactions(t *testing.T) {
 				},
 			},
 			setupPlugin: func(p *mocksPlugin.PluginIface, mockAPI *plugintest.API, store *mocksStore.Store, mockmetrics *mocksMetrics.Metrics) {
+				p.On("GetSyncReactions").Return(true).Once()
 				p.On("GetStore").Return(store).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
 				p.On("GetMetrics").Return(mockmetrics).Maybe()

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -198,6 +198,20 @@ func (_m *PluginIface) GetSyncDirectMessages() bool {
 	return r0
 }
 
+// GetSyncFileAttachments provides a mock function with given fields:
+func (_m *PluginIface) GetSyncFileAttachments() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // GetSyncGuestUsers provides a mock function with given fields:
 func (_m *PluginIface) GetSyncGuestUsers() bool {
 	ret := _m.Called()

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -226,6 +226,20 @@ func (_m *PluginIface) GetSyncGuestUsers() bool {
 	return r0
 }
 
+// GetSyncLinkedChannels provides a mock function with given fields:
+func (_m *PluginIface) GetSyncLinkedChannels() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // GetSyncReactions provides a mock function with given fields:
 func (_m *PluginIface) GetSyncReactions() bool {
 	ret := _m.Called()

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -212,6 +212,20 @@ func (_m *PluginIface) GetSyncGuestUsers() bool {
 	return r0
 }
 
+// GetSyncReactions provides a mock function with given fields:
+func (_m *PluginIface) GetSyncReactions() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // GetURL provides a mock function with given fields:
 func (_m *PluginIface) GetURL() string {
 	ret := _m.Called()

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -79,6 +79,10 @@ func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
 }
 
 func (p *Plugin) ReactionHasBeenAdded(c *plugin.Context, reaction *model.Reaction) {
+	if !p.getConfiguration().SyncReactions {
+		return
+	}
+
 	updateRequired := true
 	if c.RequestId == "" {
 		_, ignoreHookForReaction := p.activityHandler.IgnorePluginHooksMap.LoadAndDelete(fmt.Sprintf("%s_%s_%s", reaction.PostId, reaction.UserId, reaction.EmojiName))
@@ -119,6 +123,10 @@ func (p *Plugin) ReactionHasBeenAdded(c *plugin.Context, reaction *model.Reactio
 }
 
 func (p *Plugin) ReactionHasBeenRemoved(_ *plugin.Context, reaction *model.Reaction) {
+	if !p.getConfiguration().SyncReactions {
+		return
+	}
+
 	if reaction.ChannelId == "removedfromplugin" {
 		return
 	}

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -456,6 +456,10 @@ func (p *Plugin) SendChat(srcUser string, usersIDs []string, post *model.Post) (
 
 	var attachments []*clientmodels.Attachment
 	for _, fileID := range post.FileIds {
+		if !p.GetSyncFileAttachments() {
+			continue
+		}
+
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
 			p.API.LogWarn("Unable to get file info", "error", appErr)
@@ -550,6 +554,10 @@ func (p *Plugin) Send(teamID, channelID string, user *model.User, post *model.Po
 
 	var attachments []*clientmodels.Attachment
 	for _, fileID := range post.FileIds {
+		if !p.GetSyncFileAttachments() {
+			continue
+		}
+
 		fileInfo, appErr := p.API.GetFileInfo(fileID)
 		if appErr != nil {
 			p.API.LogWarn("Unable to get file info", "error", appErr)

--- a/server/message_hooks_test.go
+++ b/server/message_hooks_test.go
@@ -31,13 +31,30 @@ func TestReactionHasBeenAdded(t *testing.T) {
 	}
 	for _, test := range []struct {
 		Name         string
+		SetupPlugin  func(*Plugin)
 		SetupAPI     func(*plugintest.API)
 		SetupStore   func(*storemocks.Store)
 		SetupClient  func(*clientmocks.Client, *clientmocks.Client)
 		SetupMetrics func(*metricsmocks.Metrics)
 	}{
 		{
-			Name:     "ReactionHasBeenAdded: Unable to get the post info",
+			Name: "ReactionHasBeenAdded: disabled by configuration",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = false
+			},
+			SetupAPI: func(api *plugintest.API) {},
+			SetupStore: func(store *storemocks.Store) {
+			},
+			SetupClient:  func(client *clientmocks.Client, uclient *clientmocks.Client) {},
+			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {},
+		},
+		{
+			Name: "ReactionHasBeenAdded: Unable to get the post info",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetPostInfoByMattermostID", testutils.GetID()).Return(nil, nil).Times(1)
@@ -47,6 +64,10 @@ func TestReactionHasBeenAdded(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenAdded: Unable to get the link by channel ID",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 			},
@@ -61,6 +82,10 @@ func TestReactionHasBeenAdded(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenAdded: Unable to get the link by channel ID and channel",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(nil, testutils.GetInternalServerAppError("unable to get the channel")).Times(1)
 			},
@@ -73,6 +98,10 @@ func TestReactionHasBeenAdded(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenAdded: Unable to get the post",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get the post")).Times(1)
@@ -86,6 +115,10 @@ func TestReactionHasBeenAdded(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenAdded: Unable to set the reaction",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
@@ -107,6 +140,10 @@ func TestReactionHasBeenAdded(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenAdded: Unable to set the post last updateAt time",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
@@ -130,6 +167,10 @@ func TestReactionHasBeenAdded(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenAdded: Valid",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
@@ -154,7 +195,7 @@ func TestReactionHasBeenAdded(t *testing.T) {
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			p := newTestPlugin(t)
-			p.configuration.SyncDirectMessages = true
+			test.SetupPlugin(p)
 			test.SetupAPI(p.API.(*plugintest.API))
 			test.SetupStore(p.store.(*storemocks.Store))
 			test.SetupClient(p.msteamsAppClient.(*clientmocks.Client), p.clientBuilderWithToken("", "", "", "", nil, nil).(*clientmocks.Client))
@@ -173,13 +214,30 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 	}
 	for _, test := range []struct {
 		Name         string
+		SetupPlugin  func(*Plugin)
 		SetupAPI     func(*plugintest.API)
 		SetupStore   func(*storemocks.Store)
 		SetupClient  func(*clientmocks.Client, *clientmocks.Client)
 		SetupMetrics func(*metricsmocks.Metrics)
 	}{
 		{
-			Name:     "ReactionHasBeenRemoved: Unable to get the post info",
+			Name: "ReactionHasBeenRemoved: disabled by configuration",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = false
+			},
+			SetupAPI: func(api *plugintest.API) {},
+			SetupStore: func(store *storemocks.Store) {
+			},
+			SetupClient:  func(client *clientmocks.Client, uclient *clientmocks.Client) {},
+			SetupMetrics: func(mockmetrics *metricsmocks.Metrics) {},
+		},
+		{
+			Name: "ReactionHasBeenRemoved: Unable to get the post info",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {},
 			SetupStore: func(store *storemocks.Store) {
 				store.On("GetPostInfoByMattermostID", testutils.GetID()).Return(nil, nil).Times(1)
@@ -189,6 +247,10 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenRemoved: Unable to get the post",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetPost", testutils.GetID()).Return(nil, testutils.GetInternalServerAppError("unable to get the post")).Times(1)
 			},
@@ -202,6 +264,10 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenRemoved: Unable to get the link by channel ID",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
@@ -219,6 +285,10 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenRemoved: Unable to get the link by channel ID and channel",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
 				api.On("GetChannel", testutils.GetChannelID()).Return(nil, testutils.GetInternalServerAppError("unable to get the channel")).Times(1)
@@ -234,6 +304,10 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenRemoved: Unable to remove the reaction",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
@@ -262,6 +336,10 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenRemoved: Unable to set the post last updateAt time",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
@@ -292,6 +370,10 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 		},
 		{
 			Name: "ReactionHasBeenRemoved: Valid",
+			SetupPlugin: func(p *Plugin) {
+				p.configuration.SyncDirectMessages = true
+				p.configuration.SyncReactions = true
+			},
 			SetupAPI: func(api *plugintest.API) {
 				api.On("GetChannel", testutils.GetChannelID()).Return(testutils.GetChannel(model.ChannelTypeDirect), nil).Times(1)
 				api.On("GetPost", testutils.GetID()).Return(testutils.GetPost(testutils.GetChannelID(), testutils.GetUserID(), time.Now().UnixMicro()), nil).Times(1)
@@ -323,7 +405,7 @@ func TestReactionHasBeenRemoved(t *testing.T) {
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			p := newTestPlugin(t)
-			p.configuration.SyncDirectMessages = true
+			test.SetupPlugin(p)
 			test.SetupAPI(p.API.(*plugintest.API))
 			test.SetupStore(p.store.(*storemocks.Store))
 			test.SetupClient(p.msteamsAppClient.(*clientmocks.Client), p.clientBuilderWithToken("", "", "", "", nil, nil).(*clientmocks.Client))

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -42,6 +42,7 @@ const (
 	DiscardedReasonNotUserEvent              = "no_user_event"
 	DiscardedReasonOther                     = "other"
 	DiscardedReasonDirectMessagesDisabled    = "direct_messages_disabled"
+	DiscardedReasonLinkedChannelsDisabled    = "linked_channels_disabled"
 	DiscardedReasonInactiveUser              = "inactive_user"
 	DiscardedReasonDuplicatedPost            = "duplicated_post"
 	DiscardedReasonAlreadyAppliedChange      = "already_applied_change"

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -111,6 +111,10 @@ func (p *Plugin) GetSyncDirectMessages() bool {
 	return p.getConfiguration().SyncDirectMessages
 }
 
+func (p *Plugin) GetSyncReactions() bool {
+	return p.getConfiguration().SyncReactions
+}
+
 func (p *Plugin) GetSyncGuestUsers() bool {
 	return p.getConfiguration().SyncGuestUsers
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -111,6 +111,10 @@ func (p *Plugin) GetSyncDirectMessages() bool {
 	return p.getConfiguration().SyncDirectMessages
 }
 
+func (p *Plugin) GetSyncLinkedChannels() bool {
+	return p.getConfiguration().SyncLinkedChannels
+}
+
 func (p *Plugin) GetSyncReactions() bool {
 	return p.getConfiguration().SyncReactions
 }
@@ -322,6 +326,14 @@ func (p *Plugin) start(isRestart bool) {
 
 	// Run the job above right away so we immediately populate metrics.
 	p.checkCredentials()
+
+	// Unregister and re-register slash command to reflect any configuration changes.
+	if err = p.API.UnregisterCommand("", "msteams-sync"); err != nil {
+		p.API.LogWarn("Failed to unregister command", "error", err)
+	}
+	if err = p.API.RegisterCommand(p.createMsteamsSyncCommand(p.getConfiguration().SyncLinkedChannels)); err != nil {
+		p.API.LogError("Failed to register command", "error", err)
+	}
 }
 
 func (p *Plugin) getBase64Certificate() string {
@@ -473,10 +485,6 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 	p.userID = botID
-
-	if err = p.API.RegisterCommand(p.createMsteamsSyncCommand()); err != nil {
-		return err
-	}
 
 	if p.store == nil {
 		if p.apiClient.Store.DriverName() != model.DatabaseDriverPostgres {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -115,6 +115,10 @@ func (p *Plugin) GetSyncReactions() bool {
 	return p.getConfiguration().SyncReactions
 }
 
+func (p *Plugin) GetSyncFileAttachments() bool {
+	return p.getConfiguration().SyncFileAttachments
+}
+
 func (p *Plugin) GetSyncGuestUsers() bool {
 	return p.getConfiguration().SyncGuestUsers
 }

--- a/server/testutils/containere2e/containere2e.go
+++ b/server/testutils/containere2e/containere2e.go
@@ -63,6 +63,7 @@ func NewE2ETestPlugin(t *testing.T, extraOptions ...mmcontainer.MattermostCustom
 		"maxsizeforcompletedownload": 20,
 		"tenantid":                   "tenant-id",
 		"webhooksecret":              "webhook-secret",
+		"synclinkedchannels":         true,
 	}
 
 	options := []mmcontainer.MattermostCustomizeRequestOption{


### PR DESCRIPTION
#### Summary
Adds new configuration options to disable syncing reactions, file attachments, and linked channels, all defaulting to false. Note that this does not unlink existing channels.

![CleanShot 2024-02-09 at 17 31 11@2x](https://github.com/mattermost/mattermost-plugin-msteams-sync/assets/1023171/aa115eb7-9a51-40ad-844d-6a18657eefc4)

When the configuration for linked channels is toggled, the slash command is updated appropriately.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-56676
Fixes: https://mattermost.atlassian.net/browse/MM-56677
Fixes: https://mattermost.atlassian.net/browse/MM-56810