### PR TITLE
stop managing global chats subscription if disabled

### DIFF
--- a/server/monitor/monitor.go
+++ b/server/monitor/monitor.go
@@ -16,27 +16,29 @@ import (
 const monitoringSystemJobName = "monitoring_system"
 
 type Monitor struct {
-	client           msteams.Client
-	store            store.Store
-	api              plugin.API
-	metrics          metrics.Metrics
-	job              *cluster.Job
-	baseURL          string
-	webhookSecret    string
-	certificate      string
-	useEvaluationAPI bool
+	client             msteams.Client
+	store              store.Store
+	api                plugin.API
+	metrics            metrics.Metrics
+	job                *cluster.Job
+	baseURL            string
+	webhookSecret      string
+	certificate        string
+	useEvaluationAPI   bool
+	syncDirectMessages bool
 }
 
-func New(client msteams.Client, store store.Store, api plugin.API, metrics metrics.Metrics, baseURL string, webhookSecret string, useEvaluationAPI bool, certificate string) *Monitor {
+func New(client msteams.Client, store store.Store, api plugin.API, metrics metrics.Metrics, baseURL string, webhookSecret string, useEvaluationAPI bool, certificate string, syncDirectMessages bool) *Monitor {
 	return &Monitor{
-		client:           client,
-		store:            store,
-		api:              api,
-		metrics:          metrics,
-		baseURL:          baseURL,
-		webhookSecret:    webhookSecret,
-		useEvaluationAPI: useEvaluationAPI,
-		certificate:      certificate,
+		client:             client,
+		store:              store,
+		api:                api,
+		metrics:            metrics,
+		baseURL:            baseURL,
+		webhookSecret:      webhookSecret,
+		useEvaluationAPI:   useEvaluationAPI,
+		certificate:        certificate,
+		syncDirectMessages: syncDirectMessages,
 	}
 }
 
@@ -95,7 +97,7 @@ func (m *Monitor) RunMonitoringSystemJob() {
 		m.checkChannelsSubscriptions(msteamsSubscriptionsMap)
 	}()
 
-	m.checkGlobalSubscriptions(msteamsSubscriptionsMap, allChatsSubscription)
+	m.checkGlobalChatsSubscription(msteamsSubscriptionsMap, allChatsSubscription)
 
 	wg.Wait()
 }

--- a/server/monitor/subscriptions_test.go
+++ b/server/monitor/subscriptions_test.go
@@ -127,14 +127,14 @@ func TestMonitorCheckGlobalSubscriptions(t *testing.T) {
 			mockAPI := &plugintest.API{}
 			client := mocksClient.NewClient(t)
 			mockmetrics := mocksMetrics.NewMetrics(t)
-			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "")
+			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "", true)
 			testCase.setupClient(client)
 			testCase.setupAPI(mockAPI)
 			testutils.MockLogs(mockAPI)
 			testCase.setupStore(store)
 			testCase.setupMetrics(mockmetrics)
 
-			monitor.checkGlobalSubscriptions(testCase.msteamsSubscriptionMap, testCase.allChatsSubscription)
+			monitor.checkGlobalChatsSubscription(testCase.msteamsSubscriptionMap, testCase.allChatsSubscription)
 			store.AssertExpectations(t)
 			mockAPI.AssertExpectations(t)
 			client.AssertExpectations(t)
@@ -272,7 +272,7 @@ func TestMonitorCheckChannelSubscriptions(t *testing.T) {
 			mockAPI := &plugintest.API{}
 			client := mocksClient.NewClient(t)
 			mockmetrics := mocksMetrics.NewMetrics(t)
-			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "")
+			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "", true)
 			testCase.setupClient(client)
 			testCase.setupAPI(mockAPI)
 			testutils.MockLogs(mockAPI)
@@ -452,7 +452,7 @@ func TestMonitorRecreateGlobalSubscription(t *testing.T) {
 			mockAPI := &plugintest.API{}
 			client := mocksClient.NewClient(t)
 			mockmetrics := mocksMetrics.NewMetrics(t)
-			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "")
+			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "", true)
 			testCase.setupClient(client)
 			testCase.setupAPI(mockAPI)
 			testutils.MockLogs(mockAPI)
@@ -565,7 +565,7 @@ func TestRecreateChannelSubscription(t *testing.T) {
 			mockAPI := &plugintest.API{}
 			client := mocksClient.NewClient(t)
 			mockmetrics := mocksMetrics.NewMetrics(t)
-			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "")
+			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "", true)
 			testCase.setupClient(client)
 			testCase.setupAPI(mockAPI)
 			testutils.MockLogs(mockAPI)
@@ -656,7 +656,7 @@ func TestMonitorRecreateChatSubscription(t *testing.T) {
 			mockAPI := &plugintest.API{}
 			client := mocksClient.NewClient(t)
 			mockmetrics := mocksMetrics.NewMetrics(t)
-			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "")
+			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "", true)
 			testCase.setupClient(client)
 			testCase.setupAPI(mockAPI)
 			testutils.MockLogs(mockAPI)
@@ -733,7 +733,7 @@ func TestMonitorRefreshSubscription(t *testing.T) {
 			mockAPI := &plugintest.API{}
 			client := mocksClient.NewClient(t)
 			mockmetrics := mocksMetrics.NewMetrics(t)
-			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "")
+			monitor := New(client, store, mockAPI, mockmetrics, "base-url", "webhook-secret", false, "", true)
 			testCase.setupClient(client)
 			testCase.setupAPI(mockAPI)
 			testutils.MockLogs(mockAPI)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -268,7 +268,7 @@ func (p *Plugin) start(isRestart bool) {
 		return
 	}
 
-	p.monitor = monitor.New(p.GetClientForApp(), p.store, p.API, p.GetMetrics(), p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI, p.getBase64Certificate())
+	p.monitor = monitor.New(p.GetClientForApp(), p.store, p.API, p.GetMetrics(), p.GetURL()+"/", p.getConfiguration().WebhookSecret, p.getConfiguration().EvaluationAPI, p.getBase64Certificate(), p.GetSyncDirectMessages())
 	if err = p.monitor.Start(); err != nil {
 		p.API.LogError("Unable to start the monitoring system", "error", err.Error())
 	}


### PR DESCRIPTION
#### Summary
Honour the existing "Sync direct and group messages" setting, skipping the attempt to register a global chats subscription accordingly.

#### Ticket Link
None.