### PR TITLE
Add plugin's remoteID to all posts

### DIFF
--- a/server/handlers/converters_test.go
+++ b/server/handlers/converters_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	mocksPlugin "github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/mocks"
 	mocksMetrics "github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics/mocks"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams/clientmodels"
@@ -14,7 +16,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/testutils"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
-	"github.com/stretchr/testify/assert"
 )
 
 type FakeHTTPTransport struct{}
@@ -52,6 +53,7 @@ func TestMsgToPost(t *testing.T) {
 				p.On("GetClientForApp").Return(client).Maybe()
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
 				p.On("GetAPI").Return(mockAPI).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupAPI: func(api *plugintest.API) {
 			},
@@ -65,6 +67,7 @@ func TestMsgToPost(t *testing.T) {
 				},
 				FileIds:  model.StringArray{},
 				CreateAt: mmCreateAtTime,
+				RemoteId: model.NewString(testutils.GetRemoteID()),
 			},
 		},
 	} {

--- a/server/handlers/getters_test.go
+++ b/server/handlers/getters_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 
 	"github.com/gosimple/slug"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/oauth2"
+
 	mocksPlugin "github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/mocks"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams"
@@ -18,9 +22,6 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"golang.org/x/oauth2"
 )
 
 type pluginMock struct {
@@ -34,6 +35,7 @@ type pluginMock struct {
 	maxSizeForCompleteDownload int
 	bufferSizeForStreaming     int
 	botUserID                  string
+	remoteID                   string
 	url                        string
 	appClient                  msteams.Client
 	userClient                 msteams.Client
@@ -51,6 +53,7 @@ func (pm *pluginMock) GetSyncGuestUsers() bool                         { return 
 func (pm *pluginMock) GetMaxSizeForCompleteDownload() int              { return pm.maxSizeForCompleteDownload }
 func (pm *pluginMock) GetBufferSizeForStreaming() int                  { return pm.bufferSizeForStreaming }
 func (pm *pluginMock) GetBotUserID() string                            { return pm.botUserID }
+func (pm *pluginMock) GetRemoteID() string                             { return pm.remoteID }
 func (pm *pluginMock) GetURL() string                                  { return pm.url }
 func (pm *pluginMock) GetMetrics() metrics.Metrics                     { return pm.metrics }
 func (pm *pluginMock) GetClientForApp() msteams.Client                 { return pm.appClient }
@@ -70,6 +73,7 @@ func newTestHandler() *ActivityHandler {
 		store:                      &storemocks.Store{},
 		api:                        &plugintest.API{},
 		botUserID:                  "bot-user-id",
+		remoteID:                   "mock-remote-id",
 		url:                        "fake-url",
 		syncDirectMessages:         false,
 		syncGuestUsers:             false,

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/enescakir/emoji"
+
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/msteams/clientmodels"
@@ -50,6 +51,7 @@ type PluginIface interface {
 	GetClientForUser(string) (msteams.Client, error)
 	GetClientForTeamsUser(string) (msteams.Client, error)
 	GenerateRandomPassword() string
+	GetRemoteID() string
 }
 
 type ActivityHandler struct {

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	mocksPlugin "github.com/mattermost/mattermost-plugin-msteams-sync/server/handlers/mocks"
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics"
 	mocksMetrics "github.com/mattermost/mattermost-plugin-msteams-sync/server/metrics/mocks"
@@ -16,8 +19,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-sync/server/testutils"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestHandleCreatedActivity(t *testing.T) {
@@ -293,6 +294,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -344,6 +346,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -403,6 +406,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetSyncDirectMessages").Return(true).Times(1)
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -501,6 +505,7 @@ func TestHandleCreatedActivity(t *testing.T) {
 				p.On("GetStore").Return(store).Maybe()
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(3)
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetMessage", "mockTeamID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&clientmodels.Message{
@@ -840,6 +845,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				p.On("GetBotUserID").Return(testutils.GetSenderID()).Times(2)
 				p.On("GetSyncDirectMessages").Return(true).Once()
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetChat", testutils.GetChatID()).Return(&clientmodels.Chat{
@@ -937,6 +943,7 @@ func TestHandleUpdatedActivity(t *testing.T) {
 				p.On("GetBotUserID").Return("mock-BotUserID").Times(1)
 				p.On("GetBotUserID").Return(testutils.GetSenderID()).Times(2)
 				p.On("GetMetrics").Return(mockmetrics).Maybe()
+				p.On("GetRemoteID").Return(testutils.GetRemoteID())
 			},
 			setupClient: func(client *mocksClient.Client) {
 				client.On("GetMessage", "mockTeamID", testutils.GetChannelID(), testutils.GetMessageID()).Return(&clientmodels.Message{

--- a/server/handlers/mocks/PluginIface.go
+++ b/server/handlers/mocks/PluginIface.go
@@ -168,6 +168,20 @@ func (_m *PluginIface) GetMetrics() metrics.Metrics {
 	return r0
 }
 
+// GetRemoteID provides a mock function with given fields:
+func (_m *PluginIface) GetRemoteID() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetStore provides a mock function with given fields:
 func (_m *PluginIface) GetStore() store.Store {
 	ret := _m.Called()

--- a/server/metrics/mocks/Metrics.go
+++ b/server/metrics/mocks/Metrics.go
@@ -150,19 +150,19 @@ func (_m *Metrics) ObserveSubscription(action string) {
 	_m.Called(action)
 }
 
-// ObserveSyncMsgFileDelay provides a mock function with given fields: event, delayMillis
-func (_m *Metrics) ObserveSyncMsgFileDelay(event string, delayMillis int64) {
-	_m.Called(event, delayMillis)
+// ObserveSyncMsgFileDelay provides a mock function with given fields: action, delayMillis
+func (_m *Metrics) ObserveSyncMsgFileDelay(action string, delayMillis int64) {
+	_m.Called(action, delayMillis)
 }
 
-// ObserveSyncMsgPostDelay provides a mock function with given fields: event, delayMillis
-func (_m *Metrics) ObserveSyncMsgPostDelay(event string, delayMillis int64) {
-	_m.Called(event, delayMillis)
+// ObserveSyncMsgPostDelay provides a mock function with given fields: action, delayMillis
+func (_m *Metrics) ObserveSyncMsgPostDelay(action string, delayMillis int64) {
+	_m.Called(action, delayMillis)
 }
 
-// ObserveSyncMsgReactionDelay provides a mock function with given fields: event, delayMillis
-func (_m *Metrics) ObserveSyncMsgReactionDelay(event string, delayMillis int64) {
-	_m.Called(event, delayMillis)
+// ObserveSyncMsgReactionDelay provides a mock function with given fields: action, delayMillis
+func (_m *Metrics) ObserveSyncMsgReactionDelay(action string, delayMillis int64) {
+	_m.Called(action, delayMillis)
 }
 
 // ObserveSyntheticUsers provides a mock function with given fields: count

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -141,6 +141,10 @@ func (p *Plugin) GetBotUserID() string {
 	return p.userID
 }
 
+func (p *Plugin) GetRemoteID() string {
+	return p.remoteID
+}
+
 func (p *Plugin) GetClientForApp() msteams.Client {
 	p.msteamsAppClientMutex.RLock()
 	defer p.msteamsAppClientMutex.RUnlock()

--- a/server/testutils/data.go
+++ b/server/testutils/data.go
@@ -48,6 +48,10 @@ func GetPostID() string {
 	return "qwifdnaootmgkerodfdmwo"
 }
 
+func GetRemoteID() string {
+	return "edfscfghjiugddetrfsswe"
+}
+
 func GetInternalServerAppError(errorMsg string) *model.AppError {
 	return &model.AppError{
 		StatusCode:    http.StatusInternalServerError,
@@ -165,7 +169,8 @@ func GetPostFromTeamsMessage(createAt int64) *model.Post {
 		Props: model.StringInterface{
 			"msteams_sync_mock-BotUserID": true,
 		},
-		FileIds: model.StringArray{},
+		FileIds:  model.StringArray{},
+		RemoteId: model.NewString(GetRemoteID()),
 	}
 }
 


### PR DESCRIPTION
#### Summary
Add the plugin's remoteID to all posts.  This is needed as Shared Channels uses that field to ensure it does not pync posts back to the remote from which it came.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56826

