### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is the **Mattermost Microsoft Teams Plugin** — a Go server plugin with a React webapp bundle. It is not a standalone app; runtime requires a Mattermost Server (≥ 10.7.0) with PostgreSQL. See `README.md` for build/deploy details.
+
+### Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Go | 1.24.6+ | Pre-installed on the VM |
+| Node.js | 20.11 | Pinned in `.nvmrc`; use nvm (see below) |
+| Make | any | Primary dev entry point |
+| Docker | 28.x | Required for `make test` (Postgres testcontainers) |
+
+### Node.js version
+
+The VM ships Node 22 at `/exec-daemon/node`, which takes precedence over nvm in `PATH`. **Always prepend the nvm Node 20.11 bin directory** before running npm/make webapp targets:
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v20.11.1/bin:$PATH"
+```
+
+Install via nvm if missing: `nvm install 20.11`.
+
+### Docker for tests
+
+Go unit tests spin up an embedded Mattermost server with Postgres via testcontainers (`server/main_test.go`). Docker must be running:
+
+```bash
+# Start daemon if not running (Cloud Agent VMs use fuse-overlayfs storage driver)
+sudo dockerd &
+docker info   # verify connectivity
+```
+
+First test run pulls `postgres:15.2-alpine` (~80 MB) and takes ~3 minutes.
+
+### Common commands
+
+All commands run from the repo root:
+
+| Task | Command |
+|------|---------|
+| Build plugin bundle | `MM_SERVICESETTINGS_ENABLEDEVELOPER=true make dist` |
+| Lint (Go + webapp) | `make check-style` |
+| Unit tests | `make test` |
+| Deploy to local MM | `make deploy` (requires running Mattermost + credentials) |
+| Live reload webapp | `make watch` (requires running Mattermost) |
+
+Set `MM_SERVICESETTINGS_ENABLEDEVELOPER=true` on Linux dev machines to build only for the local arch (faster). Without it, `make server` cross-compiles for both `linux-amd64` and `linux-arm64`.
+
+### What is NOT in this repo
+
+- No `docker-compose` for Mattermost — use a local or remote Mattermost instance.
+- E2E tests (`make e2e`) require live Mattermost + Microsoft Teams + Azure AD credentials in `server/e2e/testconfig.json`.
+- `make deploy` / `make watch` need `MM_SERVICESETTINGS_SITEURL` and admin credentials or a personal access token.
+
+### Lint/test scope
+
+- **Go**: golangci-lint, go vet, mattermost-govet (license checker)
+- **Webapp**: ESLint, TypeScript (`tsc`), Jest
+- CI delegates to the shared Mattermost plugin workflow (`.github/workflows/ci.yml`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the Mattermost Microsoft Teams plugin.

## Contents

- Node.js 20.11 setup (nvm path precedence over `/exec-daemon/node`)
- Docker requirement for testcontainers-based Go tests
- Common make targets and developer mode flag
- Notes on what is not included in the repo (docker-compose, E2E credentials)

This was created as part of Cloud Agent environment setup validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b766526a-1612-4272-83c7-bea6c68303bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b766526a-1612-4272-83c7-bea6c68303bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

